### PR TITLE
style(calendar-page): migrate CSS rules to SCSS nested structure (#45)

### DIFF
--- a/src/app/features/calendar/pages/calendar/calendar-page.ts
+++ b/src/app/features/calendar/pages/calendar/calendar-page.ts
@@ -6,6 +6,6 @@ import { CalendarViewComponent } from '../../components/calendar-view/calendar-v
   standalone: true,
   imports: [ CalendarViewComponent ],
   templateUrl: './calendar-page.html',
-  styleUrl: './calendar-page.css',
+  styleUrl: './calendar-page.scss',
 })
 export class CalendarComponent {}


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/45)

## Summary
Migrated `calendar-page` component styles from CSS to SCSS, introducing nested structure while preserving the existing visual output.

## What's included
- Converted `calendar-page` styles from `.css` to `.scss`
- Refactored styles into SCSS nested structure under `:host`
- Maintained existing class structure and BEM naming conventions
- No visual or layout changes introduced