### PR TITLE
refactor(auth): rename RegisterComponent to RegisterPageComponent (#87)

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -7,7 +7,7 @@ export const routes: Routes = [
   {
     path: 'register',
     loadComponent: () =>
-      import('./features/auth/pages/register/register').then(m => m.RegisterComponent)
+      import('./features/auth/pages/register/register').then(m => m.RegisterPageComponent)
   },
   {
     path: 'login',

--- a/src/app/features/auth/pages/register/register.spec.ts
+++ b/src/app/features/auth/pages/register/register.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { Auth, UserCredential } from '@angular/fire/auth';
 import { provideRouter, Router } from '@angular/router';
 
-import { RegisterComponent } from './register';
+import { RegisterPageComponent } from './register';
 import { AuthService } from '../../data-access/auth-service';
 
 const mockAuth = {
@@ -10,16 +10,16 @@ const mockAuth = {
   onAuthStateChanged: () => {}
 };
 
-describe('RegisterComponent', () => {
-  let component: RegisterComponent;
-  let fixture: ComponentFixture<RegisterComponent>;
+describe('RegisterPageComponent', () => {
+  let component: RegisterPageComponent;
+  let fixture: ComponentFixture<RegisterPageComponent>;
   let authService: AuthService;
   let registerSpy: jasmine.Spy;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        RegisterComponent,
+        RegisterPageComponent,
       ],
       providers: [
         provideRouter([]),
@@ -28,7 +28,7 @@ describe('RegisterComponent', () => {
       ]
     }).compileComponents();
 
-    fixture = TestBed.createComponent(RegisterComponent);
+    fixture = TestBed.createComponent(RegisterPageComponent);
     component = fixture.componentInstance;
 
     authService = TestBed.inject(AuthService);

--- a/src/app/features/auth/pages/register/register.ts
+++ b/src/app/features/auth/pages/register/register.ts
@@ -15,7 +15,7 @@ import { AuthMessagesService } from '../../i18n/auth-messages';
   templateUrl: './register.html',
   styleUrl: './register.scss',
 })
-export class RegisterComponent {
+export class RegisterPageComponent {
 
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/87)

## Summary

Aligned the register page component with the project's page naming convention by renaming `RegisterComponent` to `RegisterPageComponent` and updating all related references.

## What's included

* Renamed `RegisterComponent` to `RegisterPageComponent`
* Updated component exports to use the new name
* Updated route configuration to load `RegisterPageComponent`
* Updated imports and references across the application
* Updated unit tests to use the new component name
* Verified all tests pass after the refacto