### PR TITLE
refactor(auth): rename LoginComponent to LoginPageComponent (#88)

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -12,7 +12,7 @@ export const routes: Routes = [
   {
     path: 'login',
     loadComponent: () =>
-      import('./features/auth/pages/login/login').then(m => m.LoginComponent)
+      import('./features/auth/pages/login/login').then(m => m.LoginPageComponent)
   },
   {
     path: '',

--- a/src/app/features/auth/pages/login/login.spec.ts
+++ b/src/app/features/auth/pages/login/login.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Auth, UserCredential } from '@angular/fire/auth';
 
-import { LoginComponent } from './login';
+import { LoginPageComponent } from './login';
 import { AuthService } from '../../data-access/auth-service';
 import { provideRouter, Router } from '@angular/router';
 
@@ -10,16 +10,16 @@ const mockAuth = {
   onAuthStateChanged: () => {}
 };
 
-describe('LoginComponent', () => {
-  let component: LoginComponent;
-  let fixture: ComponentFixture<LoginComponent>;
+describe('LoginPageComponent', () => {
+  let component: LoginPageComponent;
+  let fixture: ComponentFixture<LoginPageComponent>;
   let authService: AuthService;
   let loginSpy: jasmine.Spy;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        LoginComponent,
+        LoginPageComponent,
       ],
       providers: [
         provideRouter([]),
@@ -28,7 +28,7 @@ describe('LoginComponent', () => {
       ]
     }).compileComponents();
 
-    fixture = TestBed.createComponent(LoginComponent);
+    fixture = TestBed.createComponent(LoginPageComponent);
     component = fixture.componentInstance;
 
     authService = TestBed.inject(AuthService);

--- a/src/app/features/auth/pages/login/login.ts
+++ b/src/app/features/auth/pages/login/login.ts
@@ -15,7 +15,7 @@ import { AuthMessagesService } from '../../i18n/auth-messages';
   templateUrl: './login.html',
   styleUrl: './login.scss',
 })
-export class LoginComponent {
+export class LoginPageComponent {
   
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/88)

## Summary

Aligned the login page component with the project's page naming convention by renaming `LoginComponent` to `LoginPageComponent` and updating all related references.

## What's included

* Renamed `LoginComponent` to `LoginPageComponent`
* Updated component exports to use the new name
* Updated route configuration to load `LoginPageComponent`
* Updated imports and references across the application
* Updated unit tests to use the new component name
* Verified all tests pass after the refacto