### PR TITLE
refactor(vehicle): rename VehicleComponent to VehiclePageComponent (#85)

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -21,7 +21,7 @@ export const routes: Routes = [
       {
         path: '',
         loadComponent: () =>
-          import('./features/vehicle/pages/vehicle/vehicle-page').then(m => m.VehicleComponent)
+          import('./features/vehicle/pages/vehicle/vehicle-page').then(m => m.VehiclePageComponent)
       },
       {
         path: 'map',

--- a/src/app/features/vehicle/pages/vehicle/vehicle-page.spec.ts
+++ b/src/app/features/vehicle/pages/vehicle/vehicle-page.spec.ts
@@ -2,11 +2,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientModule } from '@angular/common/http';
 import { Auth } from '@angular/fire/auth';
 
-import { VehicleComponent } from './vehicle-page';
+import { VehiclePageComponent } from './vehicle-page';
 
-describe('VehicleComponent', () => {
-  let component: VehicleComponent;
-  let fixture: ComponentFixture<VehicleComponent>;
+describe('VehiclePageComponent', () => {
+  let component: VehiclePageComponent;
+  let fixture: ComponentFixture<VehiclePageComponent>;
 
   const authMock = {
     currentUser: {
@@ -17,13 +17,13 @@ describe('VehicleComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [VehicleComponent, HttpClientModule],
+      imports: [VehiclePageComponent, HttpClientModule],
       providers: [
         { provide: Auth, useValue: authMock }
       ]
     }).compileComponents();
 
-    fixture = TestBed.createComponent(VehicleComponent);
+    fixture = TestBed.createComponent(VehiclePageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/features/vehicle/pages/vehicle/vehicle-page.ts
+++ b/src/app/features/vehicle/pages/vehicle/vehicle-page.ts
@@ -8,6 +8,6 @@ import { VehicleViewComponent } from '../../components/vehicle-view/vehicle-view
   templateUrl: './vehicle-page.html',
   styleUrl: './vehicle-page.scss',
 })
-export class VehicleComponent {
+export class VehiclePageComponent {
 
 }


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/85)

## Summary

Aligned the vehicle page component with the project's page naming convention by renaming `VehicleComponent` to `VehiclePageComponent` and updating all related references.

## What's included

* Renamed `VehicleComponent` to `VehiclePageComponent`
* Updated component exports to use the new name
* Updated route configuration to load `VehiclePageComponent`
* Updated imports and references across the application
* Updated unit tests to use the new component name
* Verified all tests pass after the refacto