### PR TITLE
refactor(map): rename MapComponent to MapPageComponent (#86)

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -26,7 +26,7 @@ export const routes: Routes = [
       {
         path: 'map',
         loadComponent: () =>
-          import('./features/map/pages/map/map-page').then(m => m.MapComponent)
+          import('./features/map/pages/map/map-page').then(m => m.MapPageComponent)
       },
       {
         path: 'calendar',

--- a/src/app/features/map/pages/map/map-page.spec.ts
+++ b/src/app/features/map/pages/map/map-page.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientModule } from '@angular/common/http';
 import { Auth } from '@angular/fire/auth';
 
-import { MapComponent } from './map-page';
+import { MapPageComponent } from './map-page';
 
 export const authMock = {
   currentUser: {
@@ -11,14 +11,14 @@ export const authMock = {
   }
 }
 
-describe('MapComponent', () => {
-  let component: MapComponent;
-  let fixture: ComponentFixture<MapComponent>;
+describe('MapPageComponent', () => {
+  let component: MapPageComponent;
+  let fixture: ComponentFixture<MapPageComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        MapComponent, 
+        MapPageComponent, 
         HttpClientModule
       ],
       providers: [
@@ -26,7 +26,7 @@ describe('MapComponent', () => {
       ]
     }).compileComponents();
 
-    fixture = TestBed.createComponent(MapComponent);
+    fixture = TestBed.createComponent(MapPageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/features/map/pages/map/map-page.ts
+++ b/src/app/features/map/pages/map/map-page.ts
@@ -8,5 +8,5 @@ import { MapContainerComponent } from '../../components/map-container/map-contai
   templateUrl: './map-page.html',
   styleUrl: './map-page.scss',
 })
-export class MapComponent {
+export class MapPageComponent {
 }


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/86)

## Summary

Aligned the map page component with the project's page naming convention by renaming `MapComponent` to `MapPageComponent` and updating all related references.

## What's included

* Renamed `MapComponent` to `MapPageComponent`
* Updated component exports to use the new name
* Updated route configuration to load `MapPageComponent`
* Updated imports and references across the application
* Updated unit tests to use the new component name
* Verified all tests pass after the refacto