### PR TITLE
refactor(graphics): rename GraphicsComponent to GraphicsPageComponent (#84)

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -36,7 +36,7 @@ export const routes: Routes = [
       {
         path: 'graphics',
         loadComponent: () =>
-          import('./features/graphics/pages/graphics/graphics-page').then(m => m.GraphicsComponent)
+          import('./features/graphics/pages/graphics/graphics-page').then(m => m.GraphicsPageComponent)
       }
     ]
   },

--- a/src/app/features/graphics/pages/graphics/graphics-page.spec.ts
+++ b/src/app/features/graphics/pages/graphics/graphics-page.spec.ts
@@ -1,8 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { GraphicsComponent } from './graphics-page';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Auth } from '@angular/fire/auth';
+
+import { GraphicsPageComponent } from './graphics-page';
 
 export const authMock = {
   currentUser: {
@@ -11,14 +11,14 @@ export const authMock = {
   }
 }
 
-describe('GraphicsComponent', () => {
-  let component: GraphicsComponent;
-  let fixture: ComponentFixture<GraphicsComponent>;
+describe('GraphicsPageComponent', () => {
+  let component: GraphicsPageComponent;
+  let fixture: ComponentFixture<GraphicsPageComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        GraphicsComponent,
+        GraphicsPageComponent,
         HttpClientTestingModule
       ],
       providers: [
@@ -27,7 +27,7 @@ describe('GraphicsComponent', () => {
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(GraphicsComponent);
+    fixture = TestBed.createComponent(GraphicsPageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/features/graphics/pages/graphics/graphics-page.ts
+++ b/src/app/features/graphics/pages/graphics/graphics-page.ts
@@ -8,6 +8,6 @@ import { GraphicsViewComponent } from "../../components/graphics-view/graphics-v
   templateUrl: './graphics-page.html',
   styleUrl: './graphics-page.scss',
 })
-export class GraphicsComponent {
+export class GraphicsPageComponent {
 
 }


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/83)

## Summary

Aligned the graphics page component with the project's page naming convention by renaming `GraphicsComponent` to `GraphicsPageComponent` and updating all related references.

## What's included

* Renamed `GraphicsComponent` to `GraphicsPageComponent`
* Updated component exports to use the new name
* Updated route configuration to load `GraphicsPageComponent`
* Updated imports and references across the application
* Updated unit tests to use the new component name
* Verified all tests pass after the refacto