### PR TITLE
test(day-events-modal): add missing tests and fix failing tests for full coverage (#78)

### DIFF
--- a/src/app/features/calendar/modals/day-events-modal/day-events-modal.spec.ts
+++ b/src/app/features/calendar/modals/day-events-modal/day-events-modal.spec.ts
@@ -382,7 +382,7 @@ describe('DayEventsModalComponent', () => {
       fixture.componentRef.setInput('events', []);
       fixture.detectChanges();
 
-      const container = fixture.nativeElement.querySelector('.modal__backdrop');
+      const container = fixture.nativeElement.querySelector('.backdrop');
       expect(container.getAttribute('role')).toBe('dialog');
     });
 
@@ -390,7 +390,7 @@ describe('DayEventsModalComponent', () => {
       fixture.componentRef.setInput('events', []);
       fixture.detectChanges();
 
-      const container = fixture.nativeElement.querySelector('.modal__backdrop');
+      const container = fixture.nativeElement.querySelector('.backdrop');
       const title = fixture.nativeElement.querySelector('#dayEventsTitle');
       expect(container.getAttribute('aria-labelledby')).toBe(title.getAttribute('id'));
     });

--- a/src/app/features/calendar/modals/day-events-modal/day-events-modal.spec.ts
+++ b/src/app/features/calendar/modals/day-events-modal/day-events-modal.spec.ts
@@ -466,23 +466,78 @@ describe('DayEventsModalComponent', () => {
     });
 
     it('should bind aria-describedby correctly', () => {
-      // comprobar atributo aria-describedby del dialog
+      const eventsMock: EventInterface[] = [
+        { 
+          _id: '1', 
+          title: 'Cambio de aceite', 
+          date: '2026-02-13', 
+          hourStart: '09:00', 
+          hourEnd: '10:00', 
+          comment: '', 
+          vehicleId: '123' 
+        }
+      ];
+
+      fixture.componentRef.setInput('events', eventsMock);
+      fixture.detectChanges();
+
+      const container = fixture.nativeElement.querySelector('.backdrop');
+      const list = fixture.nativeElement.querySelector('#eventsListDesc');
+
+      expect(container.getAttribute('aria-describedby')).toBe(list.getAttribute('id'));
     });
 
     it('should generate aria-controls correctly for details', () => {
-      // renderizar eventos y comprobar aria-controls de los summary
+      const eventsMock: EventInterface[] = [
+        { _id: '1', title: 'Cambio de aceite', date: '2026-02-13', hourStart: '09:00', hourEnd: '10:00', comment: '', vehicleId: '123' },
+        { _id: '2', title: 'Inspección técnica', date: '2026-02-13', hourStart: '11:00', hourEnd: '12:00', comment: '', vehicleId: '456' }
+      ];
+
+      fixture.componentRef.setInput('events', eventsMock);
+      fixture.detectChanges();
+
+      const summaries = fixture.nativeElement.querySelectorAll('.event-card__summary');
+      const details = fixture.nativeElement.querySelectorAll('.event-card');
+
+      summaries.forEach((summary: HTMLElement, index: number) => {
+        expect(summary.getAttribute('aria-controls')).toBe(details[index].getAttribute('id'));
+      });
     });
 
     it('should render actions container with role group', () => {
-      // renderizar eventos y comprobar role="group"
+      const eventsMock: EventInterface[] = [
+        { 
+          _id: '1', 
+          title: 'Cambio de aceite', 
+          date: '2026-02-13', 
+          hourStart: '09:00', 
+          hourEnd: '10:00', 
+          comment: '', 
+          vehicleId: '123' 
+        }
+      ];
+
+      fixture.componentRef.setInput('events', eventsMock);
+      fixture.detectChanges();
+
+      const actions = fixture.nativeElement.querySelector('.event-card__actions');
+      expect(actions.getAttribute('role')).toBe('group');
     });
 
     it('should render empty state with status role', () => {
-      // renderizar sin eventos y comprobar role="status"
+      fixture.componentRef.setInput('events', []);
+      fixture.detectChanges();
+
+      const empty = fixture.nativeElement.querySelector('.modal__empty');
+      expect(empty.getAttribute('role')).toBe('status');
     });
 
     it('should render empty state with aria-live polite', () => {
-      // renderizar sin eventos y comprobar aria-live="polite"
+      fixture.componentRef.setInput('events', []);
+      fixture.detectChanges();
+
+      const empty = fixture.nativeElement.querySelector('.modal__empty');
+      expect(empty.getAttribute('aria-live')).toBe('polite');
     });
 
   });

--- a/src/app/features/calendar/modals/day-events-modal/day-events-modal.spec.ts
+++ b/src/app/features/calendar/modals/day-events-modal/day-events-modal.spec.ts
@@ -236,7 +236,11 @@ describe('DayEventsModalComponent', () => {
     });
 
     it('should not render any event card when events array is empty', () => {
-      // comprobar que no existen elementos .event-card
+      fixture.componentRef.setInput('events', eventsMock);
+      fixture.detectChanges();
+
+      const cards = fixture.nativeElement.querySelectorAll('.event-card');
+      expect(cards.length).toBe(0);
     });
 
   });

--- a/src/app/features/calendar/modals/day-events-modal/day-events-modal.spec.ts
+++ b/src/app/features/calendar/modals/day-events-modal/day-events-modal.spec.ts
@@ -15,13 +15,44 @@ describe('DayEventsModalComponent', () => {
     currentUser: { uid: 'JordiTheBest' }
   };
 
-  const mockVehicleService = {
+  const createMockVehicleService = () => ({
     vehicles: jasmine.createSpy('vehicles').and.returnValue([
       {
         _id: '123',
         name: 'Ferrari Roma'
       }
     ])
+  });
+
+  const mockEvents: EventInterface[] = [
+    {
+      _id: '1',
+      title: 'Cambio de aceite',
+      date: '2026-02-13',
+      hourStart: '09:00',
+      hourEnd: '10:00',
+      comment: 'Revisión general y cambio de filtro',
+      vehicleId: '123'
+    },
+    {
+      _id: '2',
+      title: 'Inspección técnica',
+      date: '2026-02-13',
+      hourStart: '11:00',
+      hourEnd: '12:00',
+      comment: '',
+      vehicleId: '456'
+    }
+  ];
+
+  const mockSingleEvent: EventInterface = {
+    _id: '1',
+    title: 'Cambio de aceite',
+    date: '2026-02-13',
+    hourStart: '09:00',
+    hourEnd: '10:00',
+    comment: '',
+    vehicleId: '123'
   };
 
   beforeEach(async () => {
@@ -30,7 +61,7 @@ describe('DayEventsModalComponent', () => {
       providers: [
         provideHttpClient(),
         { provide: Auth, useValue: mockAuth },
-        { provide: VehicleService, useValue: mockVehicleService }
+        { provide: VehicleService, useValue: createMockVehicleService() }
       ]
     }).compileComponents();
 
@@ -45,16 +76,6 @@ describe('DayEventsModalComponent', () => {
 
   describe('inputs', () => {
 
-    const eventMock: EventInterface = {
-      _id: '1',
-      title: 'Cambio de aceite',
-      date: '2026-02-13',
-      hourStart: '09:00',
-      hourEnd: '10:00',
-      comment: 'Revisión general y cambio de filtro',
-      vehicleId: '123'
-    };
-
     it('should assign date input correctly', () => {
       fixture.componentRef.setInput('date', '2026-02-13');
       fixture.detectChanges();
@@ -63,31 +84,31 @@ describe('DayEventsModalComponent', () => {
     });
 
     it('should assign events input correctly', () => {
-      fixture.componentRef.setInput('events', [eventMock]);
+      fixture.componentRef.setInput('events', [mockSingleEvent]);
       fixture.detectChanges();
 
-      expect(component.events()).toEqual([eventMock]);
+      expect(component.events()).toEqual([mockSingleEvent]);
     });
 
     it('should return the first event title correctly', () => {
-      fixture.componentRef.setInput('events', [eventMock]);
+      fixture.componentRef.setInput('events', [mockSingleEvent]);
       fixture.detectChanges();
 
       expect(component.events()[0].title).toBe('Cambio de aceite');
     });
 
     it('should return the first event time correctly', () => {
-      fixture.componentRef.setInput('events', [eventMock]);
+      fixture.componentRef.setInput('events', [mockSingleEvent]);
       fixture.detectChanges();
 
       expect(component.events()[0].hourStart + ' - ' + component.events()[0].hourEnd).toBe('09:00 - 10:00');
     });
 
     it('should return the first event comment correctly', () => {
-      fixture.componentRef.setInput('events', [eventMock]);
+      fixture.componentRef.setInput('events', [mockSingleEvent]);
       fixture.detectChanges();
 
-      expect(component.events()[0].comment).toBe('Revisión general y cambio de filtro');
+      expect(component.events()[0].comment).toBe('');
     });
 
   });
@@ -110,62 +131,41 @@ describe('DayEventsModalComponent', () => {
 
   describe('template rendering with events', () => {
 
-    const eventsMock: EventInterface[] = [
-      {
-        _id: '1',
-        title: 'Cambio de aceite',
-        date: '2026-02-13',
-        hourStart: '09:00',
-        hourEnd: '10:00',
-        comment: 'Revisión general y cambio de filtro',
-        vehicleId: '123'
-      },
-      {
-        _id: '2',
-        title: 'Inspección técnica',
-        date: '2026-02-13',
-        hourStart: '11:00',
-        hourEnd: '12:00',
-        comment: '',
-        vehicleId: '456'
-      }
-    ];
-
     it('should render the events list when events exist', () => {
-      fixture.componentRef.setInput('events', eventsMock);
+      fixture.componentRef.setInput('events', mockEvents);
       fixture.detectChanges();
 
-      expect(component.events().length).toBe(eventsMock.length);
+      expect(component.events().length).toBe(mockEvents.length);
     });
 
     it('should render one <li> per event', () => {
-      fixture.componentRef.setInput('events', eventsMock);
+      fixture.componentRef.setInput('events', mockEvents);
       fixture.detectChanges();
 
       const items = fixture.nativeElement.querySelectorAll('li');
-      expect(items.length).toBe(eventsMock.length);
+      expect(items.length).toBe(mockEvents.length);
     });
 
     it('should render event title correctly', () => {
-      fixture.componentRef.setInput('events', eventsMock);
+      fixture.componentRef.setInput('events', mockEvents);
       fixture.detectChanges();
 
       const title = fixture.nativeElement.querySelectorAll('.event-card__title');
-      expect(title.length).toBe(eventsMock.length);
-      expect(title[0].textContent).toContain(eventsMock[0].title);
+      expect(title.length).toBe(mockEvents.length);
+      expect(title[0].textContent).toContain(mockEvents[0].title);
     });
 
     it('should render event time correctly', () => {
-      fixture.componentRef.setInput('events', eventsMock);
+      fixture.componentRef.setInput('events', mockEvents);
       fixture.detectChanges();
 
       const time = fixture.nativeElement.querySelectorAll('.event-card__time-value');
-      expect(time.length).toBe(eventsMock.length);
-      expect(time[0].textContent).toContain(`${eventsMock[0].hourStart} - ${eventsMock[0].hourEnd}`);
+      expect(time.length).toBe(mockEvents.length);
+      expect(time[0].textContent).toContain(`${mockEvents[0].hourStart} - ${mockEvents[0].hourEnd}`);
     });
 
     it('should render comment when comment exists', () => {
-      fixture.componentRef.setInput('events', eventsMock);
+      fixture.componentRef.setInput('events', mockEvents);
       fixture.detectChanges();
 
       const comment = fixture.nativeElement.querySelectorAll('.event-card__comment');
@@ -174,28 +174,16 @@ describe('DayEventsModalComponent', () => {
     });
 
     it('should not render comment when comment is empty', () => {
-      fixture.componentRef.setInput('events', eventsMock);
+      fixture.componentRef.setInput('events', mockEvents);
       fixture.detectChanges();
 
       const comments = fixture.nativeElement.querySelectorAll('.event-card__comment');
       expect(comments.length).toBe(1);
-      expect(comments[0].textContent).toContain(eventsMock[0].comment);
+      expect(comments[0].textContent).toContain(mockEvents[0].comment);
     });
 
     it('should render vehicle name correctly', () => {
-      const eventsMock: EventInterface[] = [
-        {
-          _id: '1',
-          title: 'Cambio de aceite',
-          date: '2026-02-13',
-          hourStart: '09:00',
-          hourEnd: '10:00',
-          comment: 'Revisión general y cambio de filtro',
-          vehicleId: '123'
-        }
-      ];
-
-      fixture.componentRef.setInput('events', eventsMock);
+      fixture.componentRef.setInput('events', [mockSingleEvent]);
       fixture.detectChanges();
 
       const vehicle = fixture.nativeElement.querySelector('.event-card__vehicle');
@@ -217,10 +205,8 @@ describe('DayEventsModalComponent', () => {
 
   describe('template rendering without events', () => {
 
-    const eventsMock: EventInterface[] = [];
-
     it('should render empty state message', () => {
-      fixture.componentRef.setInput('events', eventsMock);
+      fixture.componentRef.setInput('events', []);
       fixture.detectChanges();
 
       const message = fixture.nativeElement.querySelector('.modal__empty');
@@ -228,7 +214,7 @@ describe('DayEventsModalComponent', () => {
     });
 
     it('should not render events list when no events exist', () => {
-      fixture.componentRef.setInput('events', eventsMock);
+      fixture.componentRef.setInput('events', []);
       fixture.detectChanges();
 
       const list = fixture.nativeElement.querySelector('.events-list');
@@ -236,7 +222,7 @@ describe('DayEventsModalComponent', () => {
     });
 
     it('should not render any event card when events array is empty', () => {
-      fixture.componentRef.setInput('events', eventsMock);
+      fixture.componentRef.setInput('events', []);
       fixture.detectChanges();
 
       const cards = fixture.nativeElement.querySelectorAll('.event-card');
@@ -274,7 +260,7 @@ describe('DayEventsModalComponent', () => {
 
       expect(spy).toHaveBeenCalled();
     });
-    
+
   });
 
   describe('template interactions', () => {
@@ -291,12 +277,7 @@ describe('DayEventsModalComponent', () => {
     });
 
     it('should call openDetails when summary is clicked', () => {
-      const eventsMock: EventInterface[] = [
-        { _id: '1', title: 'Cambio de aceite', date: '2026-02-13', hourStart: '09:00', hourEnd: '10:00', comment: '', vehicleId: '123' },
-        { _id: '2', title: 'Inspección técnica', date: '2026-02-13', hourStart: '11:00', hourEnd: '12:00', comment: '', vehicleId: '456' }
-      ];
-
-      fixture.componentRef.setInput('events', eventsMock);
+      fixture.componentRef.setInput('events', mockEvents);
       fixture.detectChanges();
 
       const openDetailsSpy = spyOn(component, 'openDetails');
@@ -321,18 +302,7 @@ describe('DayEventsModalComponent', () => {
     it('should emit editEvent when edit button is clicked', () => {
       const editEvent = spyOn(component.editEvent, 'emit');
 
-      const eventsMock: EventInterface[] = [
-        {
-          _id: '001',
-          title: 'Cambio de aceite',
-          date: '2026-02-13',
-          hourStart: '09:00',
-          hourEnd: '10:00',
-          comment: 'Revisión general y cambio de filtro',
-          vehicleId: '123'
-        }
-      ];
-      fixture.componentRef.setInput('events', eventsMock);
+      fixture.componentRef.setInput('events', [mockSingleEvent]);
       fixture.detectChanges();
 
       component.onEdit('001');
@@ -342,19 +312,7 @@ describe('DayEventsModalComponent', () => {
     it('should emit deleteEvent when delete button is clicked', () => {
       const deleteEvent = spyOn(component.deleteEvent, 'emit');
 
-      const eventsMock: EventInterface[] = [
-        {
-          _id: '001',
-          title: 'Cambio de aceite',
-          date: '2026-02-13',
-          hourStart: '09:00',
-          hourEnd: '10:00',
-          comment: 'Revisión general y cambio de filtro',
-          vehicleId: '123'
-        }
-      ];
-
-      fixture.componentRef.setInput('events', eventsMock);
+      fixture.componentRef.setInput('events', [mockSingleEvent]);
       fixture.detectChanges();
 
       component.onDelete('001');
@@ -387,29 +345,8 @@ describe('DayEventsModalComponent', () => {
 
   describe('openDetails', () => {
 
-    const eventsMock: EventInterface[] = [
-      {
-        _id: '001',
-        title: 'Cambio de aceite',
-        date: '2026-02-13',
-        hourStart: '09:00',
-        hourEnd: '10:00',
-        comment: 'Revisión general y cambio de filtro',
-        vehicleId: '123'
-      },
-      {
-        _id: '002',
-        title: 'Inspección técnica',
-        date: '2026-02-13',
-        hourStart: '11:00',
-        hourEnd: '12:00',
-        comment: '',
-        vehicleId: '456'
-      }
-    ];
-
     it('should close other details when one is opened', () => {
-      fixture.componentRef.setInput('events', eventsMock);
+      fixture.componentRef.setInput('events', mockEvents);
       fixture.detectChanges();
 
       const details = fixture.nativeElement.querySelectorAll('.event-card');
@@ -424,7 +361,7 @@ describe('DayEventsModalComponent', () => {
     });
 
     it('should not close the selected detail', () => {
-      fixture.componentRef.setInput('events', eventsMock);
+      fixture.componentRef.setInput('events', mockEvents);
       fixture.detectChanges();
 
       const details = fixture.nativeElement.querySelectorAll('.event-card');
@@ -466,19 +403,7 @@ describe('DayEventsModalComponent', () => {
     });
 
     it('should bind aria-describedby correctly', () => {
-      const eventsMock: EventInterface[] = [
-        { 
-          _id: '1', 
-          title: 'Cambio de aceite', 
-          date: '2026-02-13', 
-          hourStart: '09:00', 
-          hourEnd: '10:00', 
-          comment: '', 
-          vehicleId: '123' 
-        }
-      ];
-
-      fixture.componentRef.setInput('events', eventsMock);
+      fixture.componentRef.setInput('events', [mockSingleEvent]);
       fixture.detectChanges();
 
       const container = fixture.nativeElement.querySelector('.backdrop');
@@ -488,12 +413,7 @@ describe('DayEventsModalComponent', () => {
     });
 
     it('should generate aria-controls correctly for details', () => {
-      const eventsMock: EventInterface[] = [
-        { _id: '1', title: 'Cambio de aceite', date: '2026-02-13', hourStart: '09:00', hourEnd: '10:00', comment: '', vehicleId: '123' },
-        { _id: '2', title: 'Inspección técnica', date: '2026-02-13', hourStart: '11:00', hourEnd: '12:00', comment: '', vehicleId: '456' }
-      ];
-
-      fixture.componentRef.setInput('events', eventsMock);
+      fixture.componentRef.setInput('events', mockEvents);
       fixture.detectChanges();
 
       const summaries = fixture.nativeElement.querySelectorAll('.event-card__summary');
@@ -505,19 +425,7 @@ describe('DayEventsModalComponent', () => {
     });
 
     it('should render actions container with role group', () => {
-      const eventsMock: EventInterface[] = [
-        { 
-          _id: '1', 
-          title: 'Cambio de aceite', 
-          date: '2026-02-13', 
-          hourStart: '09:00', 
-          hourEnd: '10:00', 
-          comment: '', 
-          vehicleId: '123' 
-        }
-      ];
-
-      fixture.componentRef.setInput('events', eventsMock);
+      fixture.componentRef.setInput('events', [mockSingleEvent]);
       fixture.detectChanges();
 
       const actions = fixture.nativeElement.querySelector('.event-card__actions');

--- a/src/app/features/calendar/modals/day-events-modal/day-events-modal.spec.ts
+++ b/src/app/features/calendar/modals/day-events-modal/day-events-modal.spec.ts
@@ -81,6 +81,18 @@ describe('DayEventsModalComponent', () => {
 
   });
 
+  describe('getVehicleName', () => {
+
+    it('should return vehicle name when vehicle exists', () => {
+      // mockear VehicleService y comprobar que devuelve el nombre correcto
+    });
+
+    it('should return fallback when vehicle does not exist', () => {
+      // mockear VehicleService y comprobar que devuelve dayEventsMsg.vehicleFallback
+    });
+
+  });
+
   describe('template rendering with events', () => {
 
     const eventsMock: EventInterface[] = [
@@ -155,6 +167,14 @@ describe('DayEventsModalComponent', () => {
       expect(comments[0].textContent).toContain(eventsMock[0].comment);
     });
 
+    it('should render vehicle name correctly', () => {
+      // mockear VehicleService, renderizar eventos y comprobar .event-card__vehicle
+    });
+
+    it('should render modal title with selected date', () => {
+      // asignar date y comprobar contenido de .modal__title
+    });
+
   });
 
   describe('template rendering without events', () => {
@@ -175,6 +195,10 @@ describe('DayEventsModalComponent', () => {
 
       const list = fixture.nativeElement.querySelector('.events-list');
       expect(list).toBeFalsy();
+    });
+
+    it('should not render any event card when events array is empty', () => {
+      // comprobar que no existen elementos .event-card
     });
 
   });
@@ -212,6 +236,14 @@ describe('DayEventsModalComponent', () => {
   });
 
   describe('template interactions', () => {
+
+    it('should emit closeModal when backdrop is clicked', () => {
+      // hacer click sobre .backdrop y comprobar emisión
+    });
+
+    it('should call openDetails when summary is clicked', () => {
+      // spyOn(component, 'openDetails') y click sobre summary
+    });
 
     it('should emit createEvent when create button is clicked', () => {
       fixture.componentRef.setInput('events', []);
@@ -370,6 +402,26 @@ describe('DayEventsModalComponent', () => {
 
       const title = fixture.nativeElement.querySelector('.modal__title');
       expect(title.getAttribute('aria-label')).toContain(component.date());
+    });
+
+    it('should bind aria-describedby correctly', () => {
+      // comprobar atributo aria-describedby del dialog
+    });
+
+    it('should generate aria-controls correctly for details', () => {
+      // renderizar eventos y comprobar aria-controls de los summary
+    });
+
+    it('should render actions container with role group', () => {
+      // renderizar eventos y comprobar role="group"
+    });
+
+    it('should render empty state with status role', () => {
+      // renderizar sin eventos y comprobar role="status"
+    });
+
+    it('should render empty state with aria-live polite', () => {
+      // renderizar sin eventos y comprobar aria-live="polite"
     });
 
   });

--- a/src/app/features/calendar/modals/day-events-modal/day-events-modal.spec.ts
+++ b/src/app/features/calendar/modals/day-events-modal/day-events-modal.spec.ts
@@ -280,11 +280,30 @@ describe('DayEventsModalComponent', () => {
   describe('template interactions', () => {
 
     it('should emit closeModal when backdrop is clicked', () => {
-      // hacer click sobre .backdrop y comprobar emisión
+      fixture.componentRef.setInput('events', []);
+      fixture.detectChanges();
+
+      const closeModal = spyOn(component.closeModal, 'emit');
+      const backdrop = fixture.nativeElement.querySelector('.backdrop');
+      backdrop.click();
+
+      expect(closeModal).toHaveBeenCalled();
     });
 
     it('should call openDetails when summary is clicked', () => {
-      // spyOn(component, 'openDetails') y click sobre summary
+      const eventsMock: EventInterface[] = [
+        { _id: '1', title: 'Cambio de aceite', date: '2026-02-13', hourStart: '09:00', hourEnd: '10:00', comment: '', vehicleId: '123' },
+        { _id: '2', title: 'Inspección técnica', date: '2026-02-13', hourStart: '11:00', hourEnd: '12:00', comment: '', vehicleId: '456' }
+      ];
+
+      fixture.componentRef.setInput('events', eventsMock);
+      fixture.detectChanges();
+
+      const openDetailsSpy = spyOn(component, 'openDetails');
+      const summary = fixture.nativeElement.querySelector('.event-card__summary');
+      summary.click();
+
+      expect(openDetailsSpy).toHaveBeenCalledWith(0);
     });
 
     it('should emit createEvent when create button is clicked', () => {

--- a/src/app/features/calendar/modals/day-events-modal/day-events-modal.spec.ts
+++ b/src/app/features/calendar/modals/day-events-modal/day-events-modal.spec.ts
@@ -183,11 +183,34 @@ describe('DayEventsModalComponent', () => {
     });
 
     it('should render vehicle name correctly', () => {
-      // mockear VehicleService, renderizar eventos y comprobar .event-card__vehicle
+      const eventsMock: EventInterface[] = [
+        {
+          _id: '1',
+          title: 'Cambio de aceite',
+          date: '2026-02-13',
+          hourStart: '09:00',
+          hourEnd: '10:00',
+          comment: 'Revisión general y cambio de filtro',
+          vehicleId: '123'
+        }
+      ];
+
+      fixture.componentRef.setInput('events', eventsMock);
+      fixture.detectChanges();
+
+      const vehicle = fixture.nativeElement.querySelector('.event-card__vehicle');
+
+      expect(vehicle.textContent).toContain('Ferrari Roma');
     });
 
     it('should render modal title with selected date', () => {
-      // asignar date y comprobar contenido de .modal__title
+      fixture.componentRef.setInput('date', '2026-03-26');
+      fixture.componentRef.setInput('events', []);
+      fixture.detectChanges();
+
+      const title = fixture.nativeElement.querySelector('.modal__title');
+
+      expect(title.textContent).toContain('2026-03-26');
     });
 
   });

--- a/src/app/features/calendar/modals/day-events-modal/day-events-modal.spec.ts
+++ b/src/app/features/calendar/modals/day-events-modal/day-events-modal.spec.ts
@@ -5,6 +5,7 @@ import { Auth } from '@angular/fire/auth';
 import { DayEventsModalComponent } from './day-events-modal';
 
 import { EventInterface } from '../../interfaces/event';
+import { VehicleService } from '../../../vehicle/data-access/vehicle-service';
 
 describe('DayEventsModalComponent', () => {
   let component: DayEventsModalComponent;
@@ -14,12 +15,22 @@ describe('DayEventsModalComponent', () => {
     currentUser: { uid: 'JordiTheBest' }
   };
 
+  const mockVehicleService = {
+    vehicles: jasmine.createSpy('vehicles').and.returnValue([
+      {
+        _id: '123',
+        name: 'Ferrari Roma'
+      }
+    ])
+  };
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [DayEventsModalComponent],
       providers: [
         provideHttpClient(),
-        { provide: Auth, useValue: mockAuth }
+        { provide: Auth, useValue: mockAuth },
+        { provide: VehicleService, useValue: mockVehicleService }
       ]
     }).compileComponents();
 
@@ -84,11 +95,15 @@ describe('DayEventsModalComponent', () => {
   describe('getVehicleName', () => {
 
     it('should return vehicle name when vehicle exists', () => {
-      // mockear VehicleService y comprobar que devuelve el nombre correcto
+      const vehicle = component.getVehicleName('123');
+
+      expect(vehicle).toBe('Ferrari Roma');
     });
 
     it('should return fallback when vehicle does not exist', () => {
-      // mockear VehicleService y comprobar que devuelve dayEventsMsg.vehicleFallback
+      const result = component.getVehicleName('8888');
+
+      expect(result).toBe(component.dayEventsMsg.vehicleFallback);
     });
 
   });


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/78)

## Summary

Refactored and extended the test suite for `DayEventsModalComponent`, improving coverage, consistency, and maintainability. This includes extracting reusable mocks, fixing outdated selectors, and adding missing test cases for vehicle resolution, accessibility, and template interactions.

## What's included

* Extracted reusable mock data (`mockEvents`, `mockSingleEvent`)
* Refactored `VehicleService` mock into a factory function for better isolation between tests
* Reduced duplicated test data across multiple `describe` blocks
* Added tests for `getVehicleName` method (existing implementation coverage)
* Added test for rendering vehicle name in template (`.event-card__vehicle`)
* Added test for rendering modal title with selected date (`.modal__title`)
* Added test for empty state rendering when no events exist
* Added test to ensure no `.event-card` elements are rendered when events array is empty
* Added interaction test for clicking event summary triggering `openDetails`
* Fixed and completed accessibility tests
* Fixed selector inconsistency (`.backdrop` instead of `.modal__backdrop`)
* Improved test clarity and structure without changing production logic
* Ensured consistent setup across all test blocks for `DayEventsModalComponent`

