### PR TITLE
test(graphics-page): improve coverage and replace deprecated HTTP testing module (#95)

### DIFF
--- a/src/app/features/graphics/pages/graphics/graphics-page.spec.ts
+++ b/src/app/features/graphics/pages/graphics/graphics-page.spec.ts
@@ -1,8 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Auth } from '@angular/fire/auth';
+import { By } from '@angular/platform-browser';
 
 import { GraphicsPageComponent } from './graphics-page';
+import { GraphicsViewComponent } from '../../components/graphics-view/graphics-view';
 
 export const authMock = {
   currentUser: {
@@ -41,6 +43,14 @@ describe('GraphicsPageComponent', () => {
     it('should render graphics-view component', () => {
       const graphicsComponent = fixture.nativeElement.querySelector('app-graphics-view');
       expect(graphicsComponent).toBeTruthy();
+    });
+
+    it('should render GraphicsViewComponent', () => {
+      const child = fixture.debugElement.query(
+        By.directive(GraphicsViewComponent)
+      );
+
+      expect(child).toBeTruthy();
     });
 
   });

--- a/src/app/features/graphics/pages/graphics/graphics-page.spec.ts
+++ b/src/app/features/graphics/pages/graphics/graphics-page.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Auth } from '@angular/fire/auth';
 import { By } from '@angular/platform-browser';
 
@@ -21,9 +22,10 @@ describe('GraphicsPageComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         GraphicsPageComponent,
-        HttpClientTestingModule
       ],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         { provide: Auth, useValue: authMock },
       ]
     })
@@ -54,4 +56,5 @@ describe('GraphicsPageComponent', () => {
     });
 
   });
+
 });


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/95)

## Summary

Improved `GraphicsPageComponent` test coverage by validating the rendering of `GraphicsViewComponent` and updated the HTTP testing configuration to use the recommended provider-based APIs instead of the deprecated testing module.

## What's included

* Added test to verify `GraphicsViewComponent` is rendered through Angular's component tree using `By.directive`
* Kept DOM-level validation for `app-graphics-view` rendering
* Replaced deprecated `HttpClientTestingModule`
* Added `provideHttpClient`
* Added `provideHttpClientTesting`
* Updated TestBed configuration to use provider-based HTTP testing setup
* Preserved existing `Auth` mock configuration required by child component dependencies
* Improved test reliability by validating component instantiation rather than only DOM presence