### PR TITLE
test(graphics-services): add full test suite for GraphicsServices (#98)

### DIFF
--- a/src/app/features/graphics/data-access/graphics-services.spec.ts
+++ b/src/app/features/graphics/data-access/graphics-services.spec.ts
@@ -183,17 +183,68 @@ describe('GraphicsServices', () => {
 
   describe('getHoursByWeekdayPerVehicle', () => {
 
-    it('should return weekday names');
+    const getThisTuesday = (): string => {
+      const d = new Date(currentYear, currentDate.getMonth(), 1);
+      while (d.getDay() !== 2) d.setDate(d.getDate() + 1);
+      return `${currentYear}-${currentMonth}-${String(d.getDate()).padStart(2, '0')}`;
+    };
 
-    it('should initialize all vehicles with empty hours');
+    beforeEach(() => mockVehicles([{ _id: 'ferrari-1', name: 'Ferrari Roma' }]));
 
-    it('should accumulate hours on correct weekday');
+    it('should return weekday names', () => {
+      mockEvents([]);
 
-    it('should ignore events outside selected period');
+      const { weekdayNames } = service.getHoursByWeekdayPerVehicle(TimePeriod.Month);
 
-    it('should ignore events with missing required data');
+      expect(weekdayNames).toEqual(['monday','tuesday','wednesday','thursday','friday','saturday','sunday']);
+    });
 
-    it('should return empty hours when there are no events');
+    it('should initialize all vehicles with empty hours', () => {
+      mockEvents([]);
+
+      const { vehicles } = service.getHoursByWeekdayPerVehicle(TimePeriod.Month);
+
+      expect(vehicles[0].hours).toEqual([0,0,0,0,0,0,0]);
+    });
+
+    it('should accumulate hours on correct weekday', () => {
+      const tuesday = getThisTuesday();
+      mockEvents([
+        { _id: '1', vehicleId: 'ferrari-1', date: tuesday, hourStart: '09:00', hourEnd: '11:00' }
+      ]);
+
+      const { vehicles } = service.getHoursByWeekdayPerVehicle(TimePeriod.Month);
+
+      expect(vehicles[0].hours[1]).toBe(2);
+    });
+
+    it('should ignore events outside selected period', () => {
+      mockEvents([
+        { _id: '1', vehicleId: 'ferrari-1', date: lastYear, hourStart: '09:00', hourEnd: '11:00' }
+      ]);
+
+      const { vehicles } = service.getHoursByWeekdayPerVehicle(TimePeriod.Month);
+
+      expect(vehicles[0].hours.every((h: number) => h === 0)).toBeTrue();
+    });
+
+    it('should ignore events with missing required data', () => {
+      mockEvents([
+        { _id: '1', vehicleId: 'ferrari-1', date: thisMonth, hourStart: null, hourEnd: null }
+      ]);
+
+      const { vehicles } = service.getHoursByWeekdayPerVehicle(TimePeriod.Month);
+
+      expect(vehicles[0].hours.every((h: number) => h === 0)).toBeTrue();
+    });
+
+    it('should return empty hours when there are no events', () => {
+      mockEvents([]);
+
+      const { vehicles } = service.getHoursByWeekdayPerVehicle(TimePeriod.Month);
+
+      expect(vehicles[0].hours).toEqual([0,0,0,0,0,0,0]);
+    });
 
   });
 

--- a/src/app/features/graphics/data-access/graphics-services.spec.ts
+++ b/src/app/features/graphics/data-access/graphics-services.spec.ts
@@ -282,13 +282,21 @@ describe('GraphicsServices', () => {
 
   describe('calculateEventHours', () => {
 
-    it('should calculate whole hours correctly');
+    it('should calculate whole hours correctly', () => {
+      expect(service['calculateEventHours']('09:00', '11:00')).toBe(2);
+    });
 
-    it('should calculate decimal hours correctly');
+    it('should calculate decimal hours correctly', () => {
+      expect(service['calculateEventHours']('09:00', '10:30')).toBe(1.5);
+    });
 
-    it('should return zero when start and end hours are equal');
+    it('should return zero when start and end hours are equal', () => {
+      expect(service['calculateEventHours']('10:00', '10:00')).toBe(0);
+    });
 
-    it('should return negative value when end time is before start time');
+    it('should return negative value when end time is before start time', () => {
+      expect(service['calculateEventHours']('12:00', '10:00')).toBe(-2);
+    });
 
   });
 

--- a/src/app/features/graphics/data-access/graphics-services.spec.ts
+++ b/src/app/features/graphics/data-access/graphics-services.spec.ts
@@ -58,19 +58,80 @@ describe('GraphicsServices', () => {
 
   describe('getVehicleUsageHours', () => {
 
-    it('should return vehicle usage hours for current month');
+    beforeEach(() => mockVehicles());
 
-    it('should return vehicle usage hours for current year');
+    it('should return vehicle usage hours for current month', () => {
+      mockEvents([
+        { _id: '1', vehicleId: 'ferrari-1', date: thisMonth, hourStart: '09:00', hourEnd: '11:00' }
+      ]);
 
-    it('should return vehicle usage hours for all time');
+      const result = service.getVehicleUsageHours(TimePeriod.Month);
 
-    it('should ignore events without valid hours');
+      expect(result.length).toBe(1);
+      expect(result[0].vehicleId).toBe('ferrari-1');
+      expect(result[0].totalHours).toBe(2);
+    });
 
-    it('should ignore events from other vehicles');
+    it('should return vehicle usage hours for current year', () => {
+      mockEvents([
+        { _id: '1', vehicleId: 'ferrari-1', date: thisMonth, hourStart: '09:00', hourEnd: '11:00' }
+      ]);
 
-    it('should return empty array when no vehicle has usage');
+      const result = service.getVehicleUsageHours(TimePeriod.Year);
 
-    it('should accumulate hours from multiple events of same vehicle');
+      expect(result.length).toBe(1);
+      expect(result[0].totalHours).toBe(2);
+    });
+
+    it('should return vehicle usage hours for all time', () => {
+      mockEvents([
+        { _id: '1', vehicleId: 'ferrari-1', date: lastYear, hourStart: '10:00', hourEnd: '12:00' }
+      ]);
+
+      const result = service.getVehicleUsageHours(TimePeriod.AllTime);
+
+      expect(result.length).toBe(1);
+      expect(result[0].totalHours).toBe(2);
+    });
+
+    it('should ignore events without valid hours', () => {
+      mockEvents([
+        { _id: '1', vehicleId: 'ferrari-1', date: thisMonth, hourStart: null, hourEnd: null }
+      ]);
+
+      const result = service.getVehicleUsageHours(TimePeriod.Month);
+
+      expect(result.length).toBe(0);
+    });
+
+    it('should ignore events from other vehicles', () => {
+      mockEvents([
+        { _id: '1', vehicleId: 'ghost-vehicle', date: thisMonth, hourStart: '09:00', hourEnd: '11:00' }
+      ]);
+
+      const result = service.getVehicleUsageHours(TimePeriod.Month);
+
+      expect(result.length).toBe(0);
+    });
+
+    it('should return empty array when no vehicle has usage', () => {
+      mockEvents([]);
+
+      const result = service.getVehicleUsageHours(TimePeriod.Month);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should accumulate hours from multiple events of same vehicle', () => {
+      mockEvents([
+        { _id: '1', vehicleId: 'ferrari-1', date: thisMonth, hourStart: '09:00', hourEnd: '11:00' },
+        { _id: '2', vehicleId: 'ferrari-1', date: thisMonth, hourStart: '14:00', hourEnd: '16:00' }
+      ]);
+
+      const result = service.getVehicleUsageHours(TimePeriod.Month);
+
+      expect(result[0].totalHours).toBe(4);
+    });
 
   });
 

--- a/src/app/features/graphics/data-access/graphics-services.spec.ts
+++ b/src/app/features/graphics/data-access/graphics-services.spec.ts
@@ -4,6 +4,9 @@ import { provideHttpClient } from '@angular/common/http';
 import { Auth } from '@angular/fire/auth';
 
 import { GraphicsServices } from './graphics-services';
+import { EventService } from '../../calendar/data-access/event-service';
+import { VehicleService } from '../../vehicle/data-access/vehicle-service';
+import { TimePeriod } from '../enums/time-period.enum';
 
 export const authMock = {
   currentUser: {
@@ -14,6 +17,14 @@ export const authMock = {
 
 describe('GraphicsServices', () => {
   let service: GraphicsServices;
+  let eventService: EventService;
+  let vehicleService: VehicleService;
+
+  const currentDate = new Date();
+  const currentMonth = String(currentDate.getMonth() + 1).padStart(2, '0');
+  const currentYear = currentDate.getFullYear();
+  const thisMonth = `${currentYear}-${currentMonth}-15`;
+  const lastYear = `${currentYear - 1}-${currentMonth}-15`;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -24,9 +35,22 @@ describe('GraphicsServices', () => {
         provideHttpClientTesting(),
       ]
     });
-    service = TestBed.inject(GraphicsServices);
 
+    service = TestBed.inject(GraphicsServices);
+    eventService = TestBed.inject(EventService);
+    vehicleService = TestBed.inject(VehicleService);
   });
+
+  function mockVehicles(vehicles = [
+    { _id: 'ferrari-1', name: 'Ferrari Roma' },
+    { _id: 'pagani-1', name: 'Pagani Huayra' }
+  ]) {
+    spyOn(vehicleService, 'vehicles').and.returnValue(vehicles as any);
+  }
+
+  function mockEvents(events: any[]) {
+    service['eventService']['_allEvents'].set(events);
+  }
 
   it('should be created', () => {
     expect(service).toBeTruthy();

--- a/src/app/features/graphics/data-access/graphics-services.spec.ts
+++ b/src/app/features/graphics/data-access/graphics-services.spec.ts
@@ -137,11 +137,47 @@ describe('GraphicsServices', () => {
 
   describe('getMostUsedVehicle', () => {
 
-    it('should return empty array when there are no vehicles with usage');
+    beforeEach(() => {
+      mockVehicles([
+        { _id: 'ferrari-1', name: 'Ferrari Roma' },
+        { _id: 'pagani-1', name: 'Pagani Huayra' },
+        { _id: 'lambo-1', name: 'Lamborghini Huracan' },
+        { _id: 'mclaren-1', name: 'McLaren 720s' }
+      ]);
+    });
 
-    it('should return the most used vehicles sorted by total hours');
+    it('should return empty array when there are no vehicles with usage', () => {
+      mockEvents([]);
 
-    it('should return only top three vehicles');
+      const result = service.getMostUsedVehicle(TimePeriod.Month);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return the most used vehicles sorted by total hours', () => {
+      mockEvents([
+        { _id: '1', vehicleId: 'ferrari-1', date: thisMonth, hourStart: '09:00', hourEnd: '11:00' },
+        { _id: '2', vehicleId: 'pagani-1', date: thisMonth, hourStart: '09:00', hourEnd: '15:00' }
+      ]);
+
+      const result = service.getMostUsedVehicle(TimePeriod.Month);
+
+      expect(result[0].vehicleId).toBe('pagani-1');
+      expect(result[1].vehicleId).toBe('ferrari-1');
+    });
+
+    it('should return only top three vehicles', () => {
+      mockEvents([
+        { _id: '1', vehicleId: 'ferrari-1', date: thisMonth, hourStart: '09:00', hourEnd: '11:00' },
+        { _id: '2', vehicleId: 'pagani-1', date: thisMonth, hourStart: '09:00', hourEnd: '15:00' },
+        { _id: '3', vehicleId: 'lambo-1', date: thisMonth, hourStart: '09:00', hourEnd: '13:00' },
+        { _id: '4', vehicleId: 'mclaren-1', date: thisMonth, hourStart: '09:00', hourEnd: '12:00' }
+      ]);
+
+      const result = service.getMostUsedVehicle(TimePeriod.Month);
+
+      expect(result.length).toBe(3);
+    });
 
   });
 

--- a/src/app/features/graphics/data-access/graphics-services.spec.ts
+++ b/src/app/features/graphics/data-access/graphics-services.spec.ts
@@ -4,7 +4,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { Auth } from '@angular/fire/auth';
 
 import { GraphicsServices } from './graphics-services';
-import { EventService } from '../../calendar/data-access/event-service';
+
 import { VehicleService } from '../../vehicle/data-access/vehicle-service';
 import { TimePeriod } from '../enums/time-period.enum';
 
@@ -17,7 +17,6 @@ export const authMock = {
 
 describe('GraphicsServices', () => {
   let service: GraphicsServices;
-  let eventService: EventService;
   let vehicleService: VehicleService;
 
   const currentDate = new Date();
@@ -37,7 +36,6 @@ describe('GraphicsServices', () => {
     });
 
     service = TestBed.inject(GraphicsServices);
-    eventService = TestBed.inject(EventService);
     vehicleService = TestBed.inject(VehicleService);
   });
 
@@ -61,10 +59,7 @@ describe('GraphicsServices', () => {
     beforeEach(() => mockVehicles());
 
     it('should return vehicle usage hours for current month', () => {
-      mockEvents([
-        { _id: '1', vehicleId: 'ferrari-1', date: thisMonth, hourStart: '09:00', hourEnd: '11:00' }
-      ]);
-
+      mockEvents([{ _id: '1', vehicleId: 'ferrari-1', date: thisMonth, hourStart: '09:00', hourEnd: '11:00' }]);
       const result = service.getVehicleUsageHours(TimePeriod.Month);
 
       expect(result.length).toBe(1);
@@ -73,10 +68,7 @@ describe('GraphicsServices', () => {
     });
 
     it('should return vehicle usage hours for current year', () => {
-      mockEvents([
-        { _id: '1', vehicleId: 'ferrari-1', date: thisMonth, hourStart: '09:00', hourEnd: '11:00' }
-      ]);
-
+      mockEvents([{ _id: '1', vehicleId: 'ferrari-1', date: thisMonth, hourStart: '09:00', hourEnd: '11:00' }]);
       const result = service.getVehicleUsageHours(TimePeriod.Year);
 
       expect(result.length).toBe(1);
@@ -84,10 +76,7 @@ describe('GraphicsServices', () => {
     });
 
     it('should return vehicle usage hours for all time', () => {
-      mockEvents([
-        { _id: '1', vehicleId: 'ferrari-1', date: lastYear, hourStart: '10:00', hourEnd: '12:00' }
-      ]);
-
+      mockEvents([{ _id: '1', vehicleId: 'ferrari-1', date: lastYear, hourStart: '10:00', hourEnd: '12:00' }]);
       const result = service.getVehicleUsageHours(TimePeriod.AllTime);
 
       expect(result.length).toBe(1);
@@ -95,20 +84,14 @@ describe('GraphicsServices', () => {
     });
 
     it('should ignore events without valid hours', () => {
-      mockEvents([
-        { _id: '1', vehicleId: 'ferrari-1', date: thisMonth, hourStart: null, hourEnd: null }
-      ]);
-
+      mockEvents([{ _id: '1', vehicleId: 'ferrari-1', date: thisMonth, hourStart: null, hourEnd: null }]);
       const result = service.getVehicleUsageHours(TimePeriod.Month);
 
       expect(result.length).toBe(0);
     });
 
     it('should ignore events from other vehicles', () => {
-      mockEvents([
-        { _id: '1', vehicleId: 'ghost-vehicle', date: thisMonth, hourStart: '09:00', hourEnd: '11:00' }
-      ]);
-
+      mockEvents([{ _id: '1', vehicleId: 'ghost-vehicle', date: thisMonth, hourStart: '09:00', hourEnd: '11:00' }]);
       const result = service.getVehicleUsageHours(TimePeriod.Month);
 
       expect(result.length).toBe(0);
@@ -116,7 +99,6 @@ describe('GraphicsServices', () => {
 
     it('should return empty array when no vehicle has usage', () => {
       mockEvents([]);
-
       const result = service.getVehicleUsageHours(TimePeriod.Month);
 
       expect(result).toEqual([]);
@@ -127,7 +109,6 @@ describe('GraphicsServices', () => {
         { _id: '1', vehicleId: 'ferrari-1', date: thisMonth, hourStart: '09:00', hourEnd: '11:00' },
         { _id: '2', vehicleId: 'ferrari-1', date: thisMonth, hourStart: '14:00', hourEnd: '16:00' }
       ]);
-
       const result = service.getVehicleUsageHours(TimePeriod.Month);
 
       expect(result[0].totalHours).toBe(4);
@@ -141,14 +122,13 @@ describe('GraphicsServices', () => {
       mockVehicles([
         { _id: 'ferrari-1', name: 'Ferrari Roma' },
         { _id: 'pagani-1', name: 'Pagani Huayra' },
-        { _id: 'lambo-1', name: 'Lamborghini Huracan' },
-        { _id: 'mclaren-1', name: 'McLaren 720s' }
+        { _id: 'mclaren-1', name: 'McLaren P1' },
+        { _id: 'porsche-1', name: 'Porsche 911 Turbo S' },
       ]);
     });
 
     it('should return empty array when there are no vehicles with usage', () => {
       mockEvents([]);
-
       const result = service.getMostUsedVehicle(TimePeriod.Month);
 
       expect(result).toEqual([]);
@@ -159,7 +139,6 @@ describe('GraphicsServices', () => {
         { _id: '1', vehicleId: 'ferrari-1', date: thisMonth, hourStart: '09:00', hourEnd: '11:00' },
         { _id: '2', vehicleId: 'pagani-1', date: thisMonth, hourStart: '09:00', hourEnd: '15:00' }
       ]);
-
       const result = service.getMostUsedVehicle(TimePeriod.Month);
 
       expect(result[0].vehicleId).toBe('pagani-1');
@@ -170,10 +149,9 @@ describe('GraphicsServices', () => {
       mockEvents([
         { _id: '1', vehicleId: 'ferrari-1', date: thisMonth, hourStart: '09:00', hourEnd: '11:00' },
         { _id: '2', vehicleId: 'pagani-1', date: thisMonth, hourStart: '09:00', hourEnd: '15:00' },
-        { _id: '3', vehicleId: 'lambo-1', date: thisMonth, hourStart: '09:00', hourEnd: '13:00' },
+        { _id: '3', vehicleId: 'porsche-1', date: thisMonth, hourStart: '09:00', hourEnd: '13:00' },
         { _id: '4', vehicleId: 'mclaren-1', date: thisMonth, hourStart: '09:00', hourEnd: '12:00' }
       ]);
-
       const result = service.getMostUsedVehicle(TimePeriod.Month);
 
       expect(result.length).toBe(3);
@@ -193,7 +171,6 @@ describe('GraphicsServices', () => {
 
     it('should return weekday names', () => {
       mockEvents([]);
-
       const { weekdayNames } = service.getHoursByWeekdayPerVehicle(TimePeriod.Month);
 
       expect(weekdayNames).toEqual(['monday','tuesday','wednesday','thursday','friday','saturday','sunday']);
@@ -201,7 +178,6 @@ describe('GraphicsServices', () => {
 
     it('should initialize all vehicles with empty hours', () => {
       mockEvents([]);
-
       const { vehicles } = service.getHoursByWeekdayPerVehicle(TimePeriod.Month);
 
       expect(vehicles[0].hours).toEqual([0,0,0,0,0,0,0]);
@@ -209,30 +185,21 @@ describe('GraphicsServices', () => {
 
     it('should accumulate hours on correct weekday', () => {
       const tuesday = getThisTuesday();
-      mockEvents([
-        { _id: '1', vehicleId: 'ferrari-1', date: tuesday, hourStart: '09:00', hourEnd: '11:00' }
-      ]);
-
+      mockEvents([{ _id: '1', vehicleId: 'ferrari-1', date: tuesday, hourStart: '09:00', hourEnd: '11:00' }]);
       const { vehicles } = service.getHoursByWeekdayPerVehicle(TimePeriod.Month);
 
       expect(vehicles[0].hours[1]).toBe(2);
     });
 
     it('should ignore events outside selected period', () => {
-      mockEvents([
-        { _id: '1', vehicleId: 'ferrari-1', date: lastYear, hourStart: '09:00', hourEnd: '11:00' }
-      ]);
-
+      mockEvents([{ _id: '1', vehicleId: 'ferrari-1', date: lastYear, hourStart: '09:00', hourEnd: '11:00' }]);
       const { vehicles } = service.getHoursByWeekdayPerVehicle(TimePeriod.Month);
 
       expect(vehicles[0].hours.every((h: number) => h === 0)).toBeTrue();
     });
 
     it('should ignore events with missing required data', () => {
-      mockEvents([
-        { _id: '1', vehicleId: 'ferrari-1', date: thisMonth, hourStart: null, hourEnd: null }
-      ]);
-
+      mockEvents([{ _id: '1', vehicleId: 'ferrari-1', date: thisMonth, hourStart: null, hourEnd: null }]);
       const { vehicles } = service.getHoursByWeekdayPerVehicle(TimePeriod.Month);
 
       expect(vehicles[0].hours.every((h: number) => h === 0)).toBeTrue();
@@ -240,7 +207,6 @@ describe('GraphicsServices', () => {
 
     it('should return empty hours when there are no events', () => {
       mockEvents([]);
-
       const { vehicles } = service.getHoursByWeekdayPerVehicle(TimePeriod.Month);
 
       expect(vehicles[0].hours).toEqual([0,0,0,0,0,0,0]);

--- a/src/app/features/graphics/data-access/graphics-services.spec.ts
+++ b/src/app/features/graphics/data-access/graphics-services.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { Auth } from '@angular/fire/auth';
 
 import { GraphicsServices } from './graphics-services';
@@ -16,9 +17,11 @@ describe('GraphicsServices', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      imports: [],
       providers: [
         { provide: Auth, useValue: authMock },
+        provideHttpClient(),
+        provideHttpClientTesting(),
       ]
     });
     service = TestBed.inject(GraphicsServices);

--- a/src/app/features/graphics/data-access/graphics-services.spec.ts
+++ b/src/app/features/graphics/data-access/graphics-services.spec.ts
@@ -28,4 +28,77 @@ describe('GraphicsServices', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  describe('getVehicleUsageHours', () => {
+
+    it('should return vehicle usage hours for current month');
+
+    it('should return vehicle usage hours for current year');
+
+    it('should return vehicle usage hours for all time');
+
+    it('should ignore events without valid hours');
+
+    it('should ignore events from other vehicles');
+
+    it('should return empty array when no vehicle has usage');
+
+    it('should accumulate hours from multiple events of same vehicle');
+
+  });
+
+  describe('getMostUsedVehicle', () => {
+
+    it('should return empty array when there are no vehicles with usage');
+
+    it('should return the most used vehicles sorted by total hours');
+
+    it('should return only top three vehicles');
+
+  });
+
+  describe('getHoursByWeekdayPerVehicle', () => {
+
+    it('should return weekday names');
+
+    it('should initialize all vehicles with empty hours');
+
+    it('should accumulate hours on correct weekday');
+
+    it('should ignore events outside selected period');
+
+    it('should ignore events with missing required data');
+
+    it('should return empty hours when there are no events');
+
+  });
+
+  describe('isInPeriod', () => {
+
+    it('should return true for all time period');
+
+    it('should return true when event belongs to current year');
+
+    it('should return false when event does not belong to current year');
+
+    it('should return true when event belongs to current month and year');
+
+    it('should return false when event belongs to different month');
+
+    it('should return false when event belongs to different year');
+
+  });
+
+  describe('calculateEventHours', () => {
+
+    it('should calculate whole hours correctly');
+
+    it('should calculate decimal hours correctly');
+
+    it('should return zero when start and end hours are equal');
+
+    it('should return negative value when end time is before start time');
+
+  });
+
 });

--- a/src/app/features/graphics/data-access/graphics-services.spec.ts
+++ b/src/app/features/graphics/data-access/graphics-services.spec.ts
@@ -250,17 +250,33 @@ describe('GraphicsServices', () => {
 
   describe('isInPeriod', () => {
 
-    it('should return true for all time period');
+    const thisYearOtherMonth = currentDate.getMonth() === 0
+      ? `${currentYear}-02-15`
+      : `${currentYear}-01-15`;
 
-    it('should return true when event belongs to current year');
+    it('should return true for all time period', () => {
+      expect(service['isInPeriod'](lastYear, TimePeriod.AllTime)).toBeTrue();
+    });
 
-    it('should return false when event does not belong to current year');
+    it('should return true when event belongs to current year', () => {
+      expect(service['isInPeriod'](thisMonth, TimePeriod.Year)).toBeTrue();
+    });
 
-    it('should return true when event belongs to current month and year');
+    it('should return false when event does not belong to current year', () => {
+      expect(service['isInPeriod'](lastYear, TimePeriod.Year)).toBeFalse();
+    });
 
-    it('should return false when event belongs to different month');
+    it('should return true when event belongs to current month and year', () => {
+      expect(service['isInPeriod'](thisMonth, TimePeriod.Month)).toBeTrue();
+    });
 
-    it('should return false when event belongs to different year');
+    it('should return false when event belongs to different month', () => {
+      expect(service['isInPeriod'](thisYearOtherMonth, TimePeriod.Month)).toBeFalse();
+    });
+
+    it('should return false when event belongs to different year', () => {
+      expect(service['isInPeriod'](lastYear, TimePeriod.Month)).toBeFalse();
+    });
 
   });
 


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/98)

## Summary
Added the complete test suite for `GraphicsServices`, covering all public and private methods, period filtering logic, weekday distribution, and vehicle usage calculations. Includes shared helpers to reduce duplication and keep tests readable.

## What's included
- Added test suite for service creation
- Added tests for `getVehicleUsageHours` covering monthly, yearly and all-time periods, invalid hours, unknown vehicles and hour accumulation
- Added tests for `getMostUsedVehicle` covering empty results, sorting by hours and top 3 limit
- Added tests for `getHoursByWeekdayPerVehicle` covering weekday names, hour accumulation per day, period filtering and missing data
- Added tests for `isInPeriod` covering all three `TimePeriod` values and edge cases per period
- Added tests for `calculateEventHours` covering whole hours, decimal hours, equal times and negative values
- Extracted `mockVehicles()` and `mockEvents()` helpers to avoid repetition across describes
- Extracted shared date constants (`thisMonth`, `lastYear`, `currentYear`) at describe level
- Used `_allEvents.set()` to properly mutate the internal signal instead of replacing it with a spy
- Used `spyOn(vehicleService, 'vehicles')` to mock the public signal without accessing private properties