### PR TITLE
test(map-page): improve coverage and replace deprecated HTTP testing module (#109)

### DIFF
--- a/src/app/features/map/pages/map/map-page.spec.ts
+++ b/src/app/features/map/pages/map/map-page.spec.ts
@@ -1,8 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { HttpClientModule } from '@angular/common/http';
+import { provideHttpClient } from '@angular/common/http';
 import { Auth } from '@angular/fire/auth';
 
 import { MapPageComponent } from './map-page';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 export const authMock = {
   currentUser: {
@@ -19,10 +20,11 @@ describe('MapPageComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         MapPageComponent, 
-        HttpClientModule
       ],
       providers: [
         { provide: Auth, useValue: authMock },
+        provideHttpClient(),
+        provideHttpClientTesting(),
       ]
     }).compileComponents();
 

--- a/src/app/features/map/pages/map/map-page.spec.ts
+++ b/src/app/features/map/pages/map/map-page.spec.ts
@@ -1,9 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Auth } from '@angular/fire/auth';
+import { By } from '@angular/platform-browser';
 
 import { MapPageComponent } from './map-page';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { MapContainerComponent } from '../../components/map-container/map-container';
 
 export const authMock = {
   currentUser: {
@@ -40,5 +42,22 @@ describe('MapPageComponent', () => {
     });
 
   });
+
+    describe('child components rendering', () => {
+
+      it('should render graphics-view component', () => {
+        const graphicsComponent = fixture.nativeElement.querySelector('app-map-container');
+        expect(graphicsComponent).toBeTruthy();
+      });
+
+      it('should render GraphicsViewComponent', () => {
+        const child = fixture.debugElement.query(
+          By.directive(MapContainerComponent)
+        );
+
+        expect(child).toBeTruthy();
+      });
+
+    });
 
 });


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/109)

## Summary

Improved `MapPageComponent` test coverage by validating the rendering of `MapContainerComponent` and updated the HTTP testing configuration to use the recommended provider-based APIs instead of the deprecated testing module.

## What's included

* Added test to verify `MapContainerComponent` is rendered through Angular's component tree using `By.directive`
* Kept DOM-level validation for `app-map-container` rendering
* Replaced deprecated `HttpClientTestingModule`
* Added `provideHttpClient`
* Added `provideHttpClientTesting`
* Updated TestBed configuration to use provider-based HTTP testing setup
* Preserved existing `Auth` mock configuration required by child component dependencies
* Improved test reliability by validating component instantiation rather than only DOM presence