### PR TITLE
test(map-view): expand coverage and improve test structure (#114)

### DIFF
--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -335,11 +335,16 @@ describe('MapViewComponent', () => {
     });
 
     it('should do nothing when there is no selected vehicle', () => {
+      component.selectedVehicle.set(null);
 
+      expect(() => component.onCancelLocationChange()).not.toThrow();
     });
 
     it('should do nothing when there is no marker', () => {
+      component.selectedVehicle.set(mockVehicle);
+      (component as any).selectedVehicleMarker = undefined;
 
+      expect(() => component.onCancelLocationChange()).not.toThrow();
     });
 
   });

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -286,7 +286,17 @@ describe('MapViewComponent', () => {
     });
 
     it('should center map on confirmed position', () => {
+      const mapService = TestBed.inject(MapService);
+      const setViewSpy = spyOn(mapService, 'setView');
 
+      const newPos = { lat: 50, lng: 8 } as any;
+
+      component.selectedVehicle.set(mockVehicle);
+      component.newPosition.set(newPos);
+
+      component.onConfirmLocationChange();
+
+      expect(setViewSpy).toHaveBeenCalledOnceWith(newPos, 19);
     });
 
   });

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -150,15 +150,58 @@ describe('MapViewComponent', () => {
     });
 
     it('should show all vehicles when null vehicle is selected', () => {
+      const showAllVehiclesSpy = spyOn<any>(component, 'showAllVehicles');
 
+      component.showVehicle(null);
+
+      expect(showAllVehiclesSpy).toHaveBeenCalled();
     });
 
     it('should create markers for all vehicles with location', () => {
+      const mapService = TestBed.inject(MapService);
+      const markerMock = {} as L.Marker;
 
+      spyOn(mapService, 'createMarker').and.returnValue(markerMock);
+
+      vehicleService.vehicles.set([
+        {
+          _id: '1',
+          name: 'Ferrari',
+          model: 'F8',
+          plate: 'AAA',
+          location: { lat: 41, lng: 2 }
+        },
+        {
+          _id: '2',
+          name: 'Porsche',
+          model: '911',
+          plate: 'BBB',
+          location: { lat: 42, lng: 3 }
+        }
+      ]);
+      (component as any).showAllVehicles();
+
+      expect(mapService.createMarker).toHaveBeenCalledTimes(2);
     });
 
     it('should ignore vehicles without location when showing all vehicles', () => {
+      const mapService = TestBed.inject(MapService);
+      const markerMock = {} as L.Marker;
 
+      spyOn(mapService, 'createMarker').and.returnValue(markerMock);
+
+      vehicleService.vehicles.set([
+        {
+          _id: '1',
+          name: 'Ferrari',
+          model: 'F8',
+          plate: 'AAA',
+          location: undefined
+        }
+      ]);
+      (component as any).showAllVehicles();
+
+      expect(mapService.createMarker).not.toHaveBeenCalled();
     });
 
   });

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -399,7 +399,16 @@ describe('MapViewComponent', () => {
     });
 
     it('should handle geolocation errors', async () => {
+      const geo = TestBed.inject(GeolocationService);
 
+      spyOn(geo, 'getCurrentLocation').and.returnValue(Promise.reject('error'));
+      spyOn(console, 'error');
+
+      component.selectedVehicle.set(mockVehicle);
+
+      await component.onUserLocationClick();
+
+      expect(console.error).toHaveBeenCalled();
     });
 
   });

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -1,11 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { signal } from '@angular/core';
 import { Auth } from '@angular/fire/auth';
 
 import * as L from 'leaflet';
 
 import { MapViewComponent } from './map-view';
+
 import { MapService } from '../../data-access/map-service';
 import { GeolocationService } from '../../../../core/services/geolocation/geolocation-service';
 import { VehicleService } from '../../../vehicle/data-access/vehicle-service';
@@ -38,7 +40,8 @@ describe('MapViewComponent', () => {
       providers: [
         { provide: Auth, useValue: authMock },
         { provide: VehicleService, useValue: vehicleServiceMock },
-        provideHttpClient()
+        provideHttpClient(),
+        provideHttpClientTesting(),
       ]
     }).compileComponents();
 

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -20,6 +20,30 @@ export const authMock = {
   }
 };
 
+const mockVehicle1: VehicleInterface = {
+  _id: 'veh-123',
+  name: 'Ferrari',
+  model: 'F8',
+  plate: 'F123',
+  location: { lat: 41, lng: 2 }
+};
+
+const mockVehicle2: VehicleInterface = {
+  _id: 'veh-999',
+  name: 'Porsche',
+  model: '911',
+  plate: 'BBB',
+  location: { lat: 42, lng: 3 }
+};
+
+const mockVehicleWithoutLocation: VehicleInterface = {
+  _id: 'veh-456',
+  name: 'Ferrari',
+  model: 'LaFerrari',
+  plate: '123456',
+  location: undefined
+};
+
 describe('MapViewComponent', () => {
   let component: MapViewComponent;
   let fixture: ComponentFixture<MapViewComponent>;
@@ -87,7 +111,7 @@ describe('MapViewComponent', () => {
 
   describe('vehicle selection', () => {
 
-    const mockVehicle: VehicleInterface = {
+    const selectedVehicleMock: VehicleInterface = {
       _id: 'veh-123',
       name: 'Ferrari',
       model: 'F8',
@@ -96,8 +120,8 @@ describe('MapViewComponent', () => {
     };
 
     it('should set selectedVehicle when showVehicle is called', () => {
-      component.showVehicle(mockVehicle);
-      expect(component.selectedVehicle()).toBe(mockVehicle);
+      component.showVehicle(selectedVehicleMock);
+      expect(component.selectedVehicle()).toBe(selectedVehicleMock);
     });
 
     it('should remove previous vehicle marker if it exists', () => {
@@ -107,7 +131,7 @@ describe('MapViewComponent', () => {
       (component as any).selectedVehicleMarker = mockMarker;
       const removeLayerSpy = spyOn(mapService, 'removeLayer');
 
-      component.showVehicle(mockVehicle);
+      component.showVehicle(selectedVehicleMock);
 
       expect(removeLayerSpy).toHaveBeenCalledOnceWith(mockMarker);
     });
@@ -118,7 +142,7 @@ describe('MapViewComponent', () => {
 
       spyOn(mapService, 'createMarker').and.returnValue(mockMarker);
 
-      component.showVehicle(mockVehicle);
+      component.showVehicle(selectedVehicleMock);
 
       expect(mapService.createMarker).toHaveBeenCalledWith([41, 2], true);
       expect(mockMarker.on).toHaveBeenCalledWith('dragend', jasmine.any(Function));
@@ -128,23 +152,16 @@ describe('MapViewComponent', () => {
       const mapService = TestBed.inject(MapService);
       const setViewSpy = spyOn(mapService, 'setView');
 
-      component.showVehicle(mockVehicle);
+      component.showVehicle(selectedVehicleMock);
 
       expect(setViewSpy).toHaveBeenCalledOnceWith([41, 2], 19);
     });
 
     it('should do nothing if vehicle has no location', () => {
-      const vehicleWithoutLocation: VehicleInterface = {
-        _id: '1',
-        name: 'Ferrari',
-        model: 'LaFerrari',
-        plate: '123456',
-        location: undefined
-      };
       const mapService = TestBed.inject(MapService);
       const createMarkerSpy = spyOn(mapService, 'createMarker');
 
-      component.showVehicle(vehicleWithoutLocation);
+      component.showVehicle(mockVehicleWithoutLocation);
 
       expect(createMarkerSpy).not.toHaveBeenCalled();
     });
@@ -163,22 +180,7 @@ describe('MapViewComponent', () => {
 
       spyOn(mapService, 'createMarker').and.returnValue(markerMock);
 
-      vehicleService.vehicles.set([
-        {
-          _id: '1',
-          name: 'Ferrari',
-          model: 'F8',
-          plate: 'AAA',
-          location: { lat: 41, lng: 2 }
-        },
-        {
-          _id: '2',
-          name: 'Porsche',
-          model: '911',
-          plate: 'BBB',
-          location: { lat: 42, lng: 3 }
-        }
-      ]);
+      vehicleService.vehicles.set([mockVehicle1, mockVehicle2]);
       (component as any).showAllVehicles();
 
       expect(mapService.createMarker).toHaveBeenCalledTimes(2);
@@ -190,15 +192,7 @@ describe('MapViewComponent', () => {
 
       spyOn(mapService, 'createMarker').and.returnValue(markerMock);
 
-      vehicleService.vehicles.set([
-        {
-          _id: '1',
-          name: 'Ferrari',
-          model: 'F8',
-          plate: 'AAA',
-          location: undefined
-        }
-      ]);
+      vehicleService.vehicles.set([mockVehicleWithoutLocation]);
       (component as any).showAllVehicles();
 
       expect(mapService.createMarker).not.toHaveBeenCalled();
@@ -230,7 +224,7 @@ describe('MapViewComponent', () => {
 
   describe('confirm location change', () => {
 
-    const mockVehicle: VehicleInterface = {
+    const selectedVehicleMock: VehicleInterface = {
       name: 'Ferrari',
       model: 'F8',
       plate: 'F123',
@@ -245,7 +239,7 @@ describe('MapViewComponent', () => {
     });
 
     it('should not update if there is no new position', () => {
-      component.selectedVehicle.set(mockVehicle);
+      component.selectedVehicle.set(selectedVehicleMock);
       component.newPosition.set(null);
       component.onConfirmLocationChange();
 
@@ -255,7 +249,7 @@ describe('MapViewComponent', () => {
     it('should update vehicle location when confirmed', () => {
       const newPos = { lat: 50, lng: 8 } as any;
 
-      component.selectedVehicle.set(mockVehicle);
+      component.selectedVehicle.set(selectedVehicleMock);
       component.newPosition.set(newPos);
       component.onConfirmLocationChange();
 
@@ -265,7 +259,7 @@ describe('MapViewComponent', () => {
     it('should update selectedVehicle with the new location', () => {
       const newPos = { lat: 50, lng: 8 } as any;
 
-      component.selectedVehicle.set(mockVehicle);
+      component.selectedVehicle.set(selectedVehicleMock);
       component.newPosition.set(newPos);
 
       component.onConfirmLocationChange();
@@ -276,7 +270,7 @@ describe('MapViewComponent', () => {
     it('should hide confirmation modal after confirming', () => {
       const newPos = { lat: 50, lng: 8 } as any;
 
-      component.selectedVehicle.set(mockVehicle);
+      component.selectedVehicle.set(selectedVehicleMock);
       component.newPosition.set(newPos);
       component.showConfirmModal.set(true);
 
@@ -291,7 +285,7 @@ describe('MapViewComponent', () => {
 
       const newPos = { lat: 50, lng: 8 } as any;
 
-      component.selectedVehicle.set(mockVehicle);
+      component.selectedVehicle.set(selectedVehicleMock);
       component.newPosition.set(newPos);
 
       component.onConfirmLocationChange();
@@ -303,7 +297,7 @@ describe('MapViewComponent', () => {
 
   describe('cancel location change', () => {
 
-    const mockVehicle: VehicleInterface = {
+    const selectedVehicleMock: VehicleInterface = {
       _id: '123',
       name: 'Ferrari',
       model: 'F8',
@@ -314,7 +308,7 @@ describe('MapViewComponent', () => {
     it('should reset marker position to original vehicle location', () => {
       const mockMarker: any = { setLatLng: jasmine.createSpy('setLatLng') };
 
-      component.selectedVehicle.set(mockVehicle);
+      component.selectedVehicle.set(selectedVehicleMock);
       (component as any).selectedVehicleMarker = mockMarker;
 
       component.onCancelLocationChange();
@@ -325,7 +319,7 @@ describe('MapViewComponent', () => {
     it('should hide confirmation modal after cancelling', () => {
       const mockMarker: any = { setLatLng: jasmine.createSpy('setLatLng') };
 
-      component.selectedVehicle.set(mockVehicle);
+      component.selectedVehicle.set(selectedVehicleMock);
       (component as any).selectedVehicleMarker = mockMarker;
       component.showConfirmModal.set(true);
 
@@ -341,7 +335,7 @@ describe('MapViewComponent', () => {
     });
 
     it('should do nothing when there is no marker', () => {
-      component.selectedVehicle.set(mockVehicle);
+      component.selectedVehicle.set(selectedVehicleMock);
       (component as any).selectedVehicleMarker = undefined;
 
       expect(() => component.onCancelLocationChange()).not.toThrow();
@@ -351,7 +345,7 @@ describe('MapViewComponent', () => {
 
   describe('user location', () => {
 
-    const mockVehicle: VehicleInterface = {
+    const selectedVehicleMock: VehicleInterface = {
       _id: '123',
       name: 'Ferrari',
       model: 'F8',
@@ -373,7 +367,7 @@ describe('MapViewComponent', () => {
       const geo = TestBed.inject(GeolocationService);
       spyOn(geo, 'getCurrentLocation').and.returnValue(Promise.resolve([50, 8]));
 
-      component.selectedVehicle.set(mockVehicle);
+      component.selectedVehicle.set(selectedVehicleMock);
 
       await component.onUserLocationClick();
 
@@ -390,7 +384,7 @@ describe('MapViewComponent', () => {
       } as any);
       spyOn(mapService, 'setView');
 
-      component.selectedVehicle.set(mockVehicle);
+      component.selectedVehicle.set(selectedVehicleMock);
 
       await component.onUserLocationClick();
 
@@ -404,7 +398,7 @@ describe('MapViewComponent', () => {
       spyOn(geo, 'getCurrentLocation').and.returnValue(Promise.reject('error'));
       spyOn(console, 'error');
 
-      component.selectedVehicle.set(mockVehicle);
+      component.selectedVehicle.set(selectedVehicleMock);
 
       await component.onUserLocationClick();
 

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -73,6 +73,10 @@ describe('MapViewComponent', () => {
       expect(initMapSpy).toHaveBeenCalledOnceWith('map', [41.478, 2.31], 10);
     });
 
+    it('should clear markers on ngOnDestroy', () => {
+
+    });
+
   });
 
   describe('vehicle selection', () => {
@@ -137,6 +141,18 @@ describe('MapViewComponent', () => {
       component.showVehicle(vehicleWithoutLocation);
 
       expect(createMarkerSpy).not.toHaveBeenCalled();
+    });
+
+    it('should show all vehicles when null vehicle is selected', () => {
+
+    });
+
+    it('should create markers for all vehicles with location', () => {
+
+    });
+
+    it('should ignore vehicles without location when showing all vehicles', () => {
+
     });
 
   });
@@ -220,6 +236,10 @@ describe('MapViewComponent', () => {
       expect(component.showConfirmModal()).toBe(false);
     });
 
+    it('should center map on confirmed position', () => {
+
+    });
+
   });
 
   describe('cancel location change', () => {
@@ -253,6 +273,14 @@ describe('MapViewComponent', () => {
       component.onCancelLocationChange();
 
       expect(component.showConfirmModal()).toBe(false);
+    });
+
+    it('should do nothing when there is no selected vehicle', () => {
+
+    });
+
+    it('should do nothing when there is no marker', () => {
+
     });
 
   });
@@ -306,6 +334,10 @@ describe('MapViewComponent', () => {
       expect(component.selectedVehicle()?.location).toEqual({ lat: 50, lng: 8 });
     });
 
+    it('should handle geolocation errors', async () => {
+
+    });
+
   });
 
   describe('private helper methods', () => {
@@ -333,6 +365,10 @@ describe('MapViewComponent', () => {
       expect(mapService.createMarker).toHaveBeenCalledWith([41, 2], true);
       expect(mockMarker.on).toHaveBeenCalledWith('dragend', jasmine.any(Function));
       expect(setViewSpy).toHaveBeenCalledOnceWith([41, 2], 19);
+    });
+
+    it('should clear selected marker', () => {
+
     });
 
   });

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -441,7 +441,17 @@ describe('MapViewComponent', () => {
     });
 
     it('should clear selected marker', () => {
+      const mapService = TestBed.inject(MapService);
+      const marker = {} as L.Marker;
 
+      (component as any).selectedVehicleMarker = marker;
+
+      const removeLayerSpy = spyOn(mapService, 'removeLayer');
+
+      (component as any).clearSelectedMarker();
+
+      expect(removeLayerSpy).toHaveBeenCalledOnceWith(marker);
+      expect((component as any).selectedVehicleMarker).toBeUndefined();
     });
 
   });

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -74,7 +74,13 @@ describe('MapViewComponent', () => {
     });
 
     it('should clear markers on ngOnDestroy', () => {
+      const clearAllMarkersSpy = spyOn<any>(component, 'clearAllMarkers');
+      const clearSelectedMarkerSpy = spyOn<any>(component, 'clearSelectedMarker');
 
+      component.ngOnDestroy();
+
+      expect(clearAllMarkersSpy).toHaveBeenCalled();
+      expect(clearSelectedMarkerSpy).toHaveBeenCalled();
     });
 
   });


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/114)

## Summary  
Expanded and improved the test coverage for `MapViewComponent`, adding missing unit tests for lifecycle behavior, vehicle selection, geolocation, marker handling, and template rendering. The suite was also cleaned up with better structure and reusable mocks.

## What's included  
- Added lifecycle test for `ngOnDestroy` (marker cleanup)  
- Extended vehicle selection tests:
  - null selection (show all vehicles)
  - multiple vehicles rendering
  - ignoring vehicles without location  
- Added coverage for confirm and cancel location flows (state updates, map centering, safe handling)
- Improved geolocation tests:
  - request only when vehicle is selected
  - successful update flow
  - error handling  
- Extended helper method coverage for marker creation and cleanup  
- Improved template tests (map container, selector, conditional UI rendering)
- Refactored test structure and introduced reusable mocks