### PR TITLE
test(details-panel): expand coverage and improve test structure (#116)

### DIFF
--- a/src/app/features/map/components/details-panel/details-panel.spec.ts
+++ b/src/app/features/map/components/details-panel/details-panel.spec.ts
@@ -136,11 +136,13 @@ describe('DetailsPanelComponent', () => {
     });
 
     it('should set title attribute from messages service', () => {
-
+      const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+      expect(button.getAttribute('title')).toBe(MockDetailsPanel.detailsPanel.aria.buttonTitle);
     });
 
     it('should set aria-label on article using region message', () => {
-
+      const article: HTMLElement = fixture.nativeElement.querySelector('article');
+      expect(article.getAttribute('aria-label')).toBe(MockDetailsPanel.detailsPanel.aria.region);
     });
 
     it('should render the icon element', () => {
@@ -163,7 +165,8 @@ describe('DetailsPanelComponent', () => {
     });
 
     it('should render button text from messages service', () => {
-
+      const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+      expect(button.textContent).toContain(MockDetailsPanel.detailsPanel.button);
     });
 
   });

--- a/src/app/features/map/components/details-panel/details-panel.spec.ts
+++ b/src/app/features/map/components/details-panel/details-panel.spec.ts
@@ -1,15 +1,32 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DetailsPanelComponent } from './details-panel';
+import { MapMessagesService } from '../../i18n/map-messages';
 
 describe('DetailsPanelComponent', () => {
   let component: DetailsPanelComponent;
   let fixture: ComponentFixture<DetailsPanelComponent>;
 
+  const messagesMock = {
+    detailsPanel: {
+      aria: {
+        region: 'Vehicle panel region',
+        button: 'Center map on vehicle',
+        buttonTitle: 'Center map on current vehicle location'
+      },
+      button: 'Center'
+    }
+  };
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [DetailsPanelComponent]
-    })
-    .compileComponents();
+      imports: [DetailsPanelComponent],
+      providers: [
+        {
+          provide: MapMessagesService,
+          useValue: messagesMock
+        }
+      ]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(DetailsPanelComponent);
     component = fixture.componentInstance;

--- a/src/app/features/map/components/details-panel/details-panel.spec.ts
+++ b/src/app/features/map/components/details-panel/details-panel.spec.ts
@@ -2,30 +2,38 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DetailsPanelComponent } from './details-panel';
 import { MapMessagesService } from '../../i18n/map-messages';
 
+const MockDetailsPanel = {
+  mapView: {
+    aria: {
+      mapRegion: '',
+      mapDescription: ''
+    },
+    confirmModal: {
+      title: '',
+      message: ''
+    }
+  },
+  detailsPanel: {
+    button: 'Center on Me',
+    aria: {
+      region: 'Selected vehicle details',
+      button: 'Center map on current location',
+      buttonTitle: "Click to center the map on the vehicle's location"
+    }
+  }
+};
+
+const MockVehicle = {
+  _id: '1',
+  name: 'Ferrari',
+  model: 'F8',
+  plate: 'F123',
+  location: { lat: 41, lng: 2 }
+};
+
 describe('DetailsPanelComponent', () => {
   let component: DetailsPanelComponent;
   let fixture: ComponentFixture<DetailsPanelComponent>;
-
-  const MockDetailsPanel = {
-    mapView: {
-      aria: {
-        mapRegion: '',
-        mapDescription: ''
-      },
-      confirmModal: {
-        title: '',
-        message: ''
-      }
-    },
-    detailsPanel: {
-      button: 'Center on Me',
-      aria: {
-        region: 'Selected vehicle details',
-        button: 'Center map on current location',
-        buttonTitle: "Click to center the map on the vehicle's location"
-      }
-    }
-  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -77,36 +85,14 @@ describe('DetailsPanelComponent', () => {
   });
 
   describe('Vehicle rendering', () => {
-
-    it('should render vehicle name when vehicle is provided', () => {
-      const vehicleMock = {
-        _id: '1',
-        name: 'Ferrari',
-        model: 'F8',
-        plate: 'F123',
-        location: { lat: 41, lng: 2 }
-      };
-
-      fixture.componentRef.setInput('vehicle', vehicleMock);
+    it('should render vehicle data when provided', () => {
+      fixture.componentRef.setInput('vehicle', MockVehicle);
       fixture.detectChanges();
 
       const name = fixture.nativeElement.querySelector('#map-card-title');
-      expect(name.textContent).toContain('Ferrari');
-    });
-
-    it('should render vehicle plate when vehicle is provided', () => {
-      const vehicleMock = {
-        _id: '1',
-        name: 'Ferrari',
-        model: 'F8',
-        plate: 'F123',
-        location: { lat: 41, lng: 2 }
-      };
-
-      fixture.componentRef.setInput('vehicle', vehicleMock);
-      fixture.detectChanges();
-
       const plate = fixture.nativeElement.querySelector('#vehicle-plate');
+
+      expect(name.textContent).toContain('Ferrari');
       expect(plate.textContent).toContain('F123');
     });
 

--- a/src/app/features/map/components/details-panel/details-panel.spec.ts
+++ b/src/app/features/map/components/details-panel/details-panel.spec.ts
@@ -76,6 +76,22 @@ describe('DetailsPanelComponent', () => {
 
   });
 
+  describe('Vehicle rendering', () => {
+
+    it('should render vehicle name when vehicle is provided', () => {
+
+    });
+
+    it('should render vehicle plate when vehicle is provided', () => {
+
+    });
+
+    it('should render empty values when vehicle is null', () => {
+
+    });
+
+  });
+
   describe('Accessibility and template', () => {
 
     it('should render a button element', () => {
@@ -86,6 +102,14 @@ describe('DetailsPanelComponent', () => {
     it('should have correct aria-label', () => {
       const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
       expect(button.getAttribute('aria-label')).toBe(MockDetailsPanel.detailsPanel.aria.button);
+    });
+
+    it('should set title attribute from messages service', () => {
+
+    });
+
+    it('should set aria-label on article using region message', () => {
+
     });
 
     it('should render the icon element', () => {
@@ -105,6 +129,10 @@ describe('DetailsPanelComponent', () => {
     it('should have aria-hidden true on icon', () => {
       const icon: HTMLElement = fixture.nativeElement.querySelector('i');
       expect(icon.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('should render button text from messages service', () => {
+      
     });
 
   });

--- a/src/app/features/map/components/details-panel/details-panel.spec.ts
+++ b/src/app/features/map/components/details-panel/details-panel.spec.ts
@@ -79,15 +79,46 @@ describe('DetailsPanelComponent', () => {
   describe('Vehicle rendering', () => {
 
     it('should render vehicle name when vehicle is provided', () => {
+      const vehicleMock = {
+        _id: '1',
+        name: 'Ferrari',
+        model: 'F8',
+        plate: 'F123',
+        location: { lat: 41, lng: 2 }
+      };
 
+      fixture.componentRef.setInput('vehicle', vehicleMock);
+      fixture.detectChanges();
+
+      const name = fixture.nativeElement.querySelector('#map-card-title');
+      expect(name.textContent).toContain('Ferrari');
     });
 
     it('should render vehicle plate when vehicle is provided', () => {
+      const vehicleMock = {
+        _id: '1',
+        name: 'Ferrari',
+        model: 'F8',
+        plate: 'F123',
+        location: { lat: 41, lng: 2 }
+      };
 
+      fixture.componentRef.setInput('vehicle', vehicleMock);
+      fixture.detectChanges();
+
+      const plate = fixture.nativeElement.querySelector('#vehicle-plate');
+      expect(plate.textContent).toContain('F123');
     });
 
     it('should render empty values when vehicle is null', () => {
+      fixture.componentRef.setInput('vehicle', null);
+      fixture.detectChanges();
 
+      const name = fixture.nativeElement.querySelector('#map-card-title');
+      const plate = fixture.nativeElement.querySelector('#vehicle-plate');
+
+      expect(name.textContent.trim()).toBe('');
+      expect(plate.textContent.trim()).toBe('');
     });
 
   });
@@ -132,7 +163,7 @@ describe('DetailsPanelComponent', () => {
     });
 
     it('should render button text from messages service', () => {
-      
+
     });
 
   });

--- a/src/app/features/map/components/details-panel/details-panel.spec.ts
+++ b/src/app/features/map/components/details-panel/details-panel.spec.ts
@@ -6,14 +6,24 @@ describe('DetailsPanelComponent', () => {
   let component: DetailsPanelComponent;
   let fixture: ComponentFixture<DetailsPanelComponent>;
 
-  const messagesMock = {
-    detailsPanel: {
+  const MockDetailsPanel = {
+    mapView: {
       aria: {
-        region: 'Vehicle panel region',
-        button: 'Center map on vehicle',
-        buttonTitle: 'Center map on current vehicle location'
+        mapRegion: '',
+        mapDescription: ''
       },
-      button: 'Center'
+      confirmModal: {
+        title: '',
+        message: ''
+      }
+    },
+    detailsPanel: {
+      button: 'Center on Me',
+      aria: {
+        region: 'Selected vehicle details',
+        button: 'Center map on current location',
+        buttonTitle: "Click to center the map on the vehicle's location"
+      }
     }
   };
 
@@ -23,7 +33,7 @@ describe('DetailsPanelComponent', () => {
       providers: [
         {
           provide: MapMessagesService,
-          useValue: messagesMock
+          useValue: MockDetailsPanel
         }
       ]
     }).compileComponents();
@@ -75,7 +85,7 @@ describe('DetailsPanelComponent', () => {
 
     it('should have correct aria-label', () => {
       const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
-      expect(button.getAttribute('aria-label')).toBe('Center map on current location');
+      expect(button.getAttribute('aria-label')).toBe(MockDetailsPanel.detailsPanel.aria.button);
     });
 
     it('should render the icon element', () => {


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/116)

## Summary  
Updated and expanded the test coverage for `DetailsPanelComponent`, adding support for i18n messages and improving vehicle rendering and accessibility tests.

## What's included  
- Added `MapMessagesService` mock for i18n support  
- Added tests for vehicle rendering (data and null cases)  
- Updated accessibility tests to use message service values (aria-label, title, region, button text)  
- Kept existing button interaction tests (click emit, default state)  
- Verified template rendering (icon, classes, aria attributes)