### PR TITLE
test(map-service): add full unit test coverage for MapService (#117)

### DIFF
--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import * as L from 'leaflet';
 
 import { MapService } from './map-service';
 
@@ -16,11 +17,35 @@ describe('MapService', () => {
 
   describe('initMap', () => {
 
-    it('should initialize the map');
+    beforeEach(() => {
+      const div = document.createElement('div');
+      div.id = 'map';
+      document.body.appendChild(div);
+    });
 
-    it('should configure the tile layer');
+    afterEach(() => {
+      document.getElementById('map')?.remove();
+      service.destroy();
+    });
 
-    it('should return the created map');
+    it('should initialize the map', () => {
+      const map = service.initMap('map', [41.3851, 2.1734], 13);
+
+      expect(map).toBeTruthy();
+    });
+
+    it('should configure the tile layer', () => {
+      const map = service.initMap('map', [41.3851, 2.1734], 13);
+      const tileLayers = Object.values((map as any)._layers).filter(layer => layer instanceof L.TileLayer);
+
+      expect(tileLayers.length).toBe(1);
+    });
+
+    it('should return the created map', () => {
+      const result = service.initMap('map', [41.3851, 2.1734], 13);
+
+      expect(result).toBe(service.getMap());
+    });
 
   });
 

--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -77,17 +77,54 @@ describe('MapService', () => {
 
   describe('createMarker', () => {
 
-    it('should create a marker with default draggable value');
+    beforeEach(() => {
+      const div = document.createElement('div');
+      div.id = 'map';
+      document.body.appendChild(div);
 
-    it('should create a marker with draggable set to true');
+      service.initMap('map', [41.3851, 2.1734], 13);
+    });
 
-    it('should create a marker with draggable set to false');
+    afterEach(() => {
+      document.getElementById('map')?.remove();
+      service.destroy();
+    });
 
-    it('should use the configured location icon');
+    it('should create a marker with default draggable value', () => {
+      const marker = service.createMarker([41.3851, 2.1734]);
 
-    it('should add the marker to the map');
+      expect(marker.dragging?.enabled()).toBeTrue();
+    });
 
-    it('should return the created marker');
+    it('should create a marker with draggable set to true', () => {
+      const marker = service.createMarker([41.3851, 2.1734], true);
+
+      expect(marker.dragging?.enabled()).toBeTrue();
+    });
+
+    it('should create a marker with draggable set to false', () => {
+      const marker = service.createMarker([41.3851, 2.1734], false);
+
+      expect(marker.dragging?.enabled()).toBeFalse();
+    });
+
+    it('should use the configured location icon', () => {
+      const marker = service.createMarker([41.3851, 2.1734]);
+
+      expect((marker.options as any).icon).toBe(service.locationIcon);
+    });
+
+    it('should add the marker to the map', () => {
+      const marker = service.createMarker([41.3851, 2.1734]);
+
+      expect(service.getMap().hasLayer(marker)).toBeTrue();
+    });
+
+    it('should return the created marker', () => {
+      const marker = service.createMarker([41.3851, 2.1734]);
+
+      expect(marker instanceof L.Marker).toBeTrue();
+    });
 
   });
 

--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -13,4 +13,75 @@ describe('MapService', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  describe('initMap', () => {
+
+    it('should initialize the map');
+
+    it('should configure the tile layer');
+
+    it('should return the created map');
+
+  });
+
+  describe('getMap', () => {
+
+    it('should return the initialized map');
+
+    it('should throw an error when map is not initialized');
+
+  });
+
+  describe('createMarker', () => {
+
+    it('should create a marker with default draggable value');
+
+    it('should create a marker with draggable set to true');
+
+    it('should create a marker with draggable set to false');
+
+    it('should use the configured location icon');
+
+    it('should add the marker to the map');
+
+    it('should return the created marker');
+
+  });
+
+  describe('setView', () => {
+
+    it('should set the map view with provided coordinates');
+
+    it('should set the map view with provided zoom');
+
+    it('should use default zoom when none is provided');
+
+  });
+
+  describe('removeLayer', () => {
+
+    it('should remove the provided layer from the map');
+
+  });
+
+  describe('destroy', () => {
+  
+    it('should remove the map when initialized');
+
+    it('should not throw when map is not initialized');
+
+  });
+
+  describe('locationIcon', () => {
+
+    it('should initialize the location icon');
+
+    it('should configure the icon urls');
+
+    it('should configure the icon size');
+
+    it('should configure the shadow anchor');
+
+  });
+
 });

--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -168,7 +168,28 @@ describe('MapService', () => {
 
   describe('removeLayer', () => {
 
-    it('should remove the provided layer from the map');
+    beforeEach(() => {
+      const div = document.createElement('div');
+      div.id = 'map';
+      document.body.appendChild(div);
+
+      service.initMap('map', [41.3851, 2.1734], 13);
+    });
+
+    afterEach(() => {
+      document.getElementById('map')?.remove();
+      service.destroy();
+    });
+
+    it('should remove the provided layer from the map', () => {
+      const map = service.getMap();
+      const removeLayerSpy = spyOn(map, 'removeLayer').and.callThrough();
+      const marker = service.createMarker([41.3851, 2.1734]);
+
+      service.removeLayer(marker);
+
+      expect(removeLayerSpy).toHaveBeenCalledWith(marker);
+    });
 
   });
 

--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -3,8 +3,19 @@ import * as L from 'leaflet';
 
 import { MapService } from './map-service';
 
+function createMapDom() {
+  const div = document.createElement('div');
+  div.id = 'map';
+  document.body.appendChild(div);
+}
+
 describe('MapService', () => {
   let service: MapService;
+
+  function cleanupMapDom() {
+    document.getElementById('map')?.remove();
+    service.destroy();
+  }
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
@@ -18,14 +29,11 @@ describe('MapService', () => {
   describe('initMap', () => {
 
     beforeEach(() => {
-      const div = document.createElement('div');
-      div.id = 'map';
-      document.body.appendChild(div);
+      createMapDom();
     });
 
     afterEach(() => {
-      document.getElementById('map')?.remove();
-      service.destroy();
+      cleanupMapDom();
     });
 
     it('should initialize the map', () => {
@@ -52,14 +60,11 @@ describe('MapService', () => {
   describe('getMap', () => {
 
     beforeEach(() => {
-      const div = document.createElement('div');
-      div.id = 'map';
-      document.body.appendChild(div);
+      createMapDom();
     });
 
     afterEach(() => {
-      document.getElementById('map')?.remove();
-      service.destroy();
+      cleanupMapDom();
     });
 
     it('should return the initialized map', () => {
@@ -78,16 +83,12 @@ describe('MapService', () => {
   describe('createMarker', () => {
 
     beforeEach(() => {
-      const div = document.createElement('div');
-      div.id = 'map';
-      document.body.appendChild(div);
-
+      createMapDom();
       service.initMap('map', [41.3851, 2.1734], 13);
     });
 
     afterEach(() => {
-      document.getElementById('map')?.remove();
-      service.destroy();
+      cleanupMapDom();
     });
 
     it('should create a marker with default draggable value', () => {
@@ -131,16 +132,12 @@ describe('MapService', () => {
   describe('setView', () => {
 
     beforeEach(() => {
-      const div = document.createElement('div');
-      div.id = 'map';
-      document.body.appendChild(div);
-
+      createMapDom();
       service.initMap('map', [41.3851, 2.1734], 13);
     });
 
     afterEach(() => {
-      document.getElementById('map')?.remove();
-      service.destroy();
+      cleanupMapDom();
     });
 
     it('should set the map view with provided coordinates', () => {
@@ -169,16 +166,12 @@ describe('MapService', () => {
   describe('removeLayer', () => {
 
     beforeEach(() => {
-      const div = document.createElement('div');
-      div.id = 'map';
-      document.body.appendChild(div);
-
+      createMapDom();
       service.initMap('map', [41.3851, 2.1734], 13);
     });
 
     afterEach(() => {
-      document.getElementById('map')?.remove();
-      service.destroy();
+      cleanupMapDom();
     });
 
     it('should remove the provided layer from the map', () => {
@@ -196,9 +189,7 @@ describe('MapService', () => {
   describe('destroy', () => {
 
     beforeEach(() => {
-      const div = document.createElement('div');
-      div.id = 'map';
-      document.body.appendChild(div);
+      createMapDom();
     });
 
     afterEach(() => {

--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -51,9 +51,27 @@ describe('MapService', () => {
 
   describe('getMap', () => {
 
-    it('should return the initialized map');
+    beforeEach(() => {
+      const div = document.createElement('div');
+      div.id = 'map';
+      document.body.appendChild(div);
+    });
 
-    it('should throw an error when map is not initialized');
+    afterEach(() => {
+      document.getElementById('map')?.remove();
+      service.destroy();
+    });
+
+    it('should return the initialized map', () => {
+      const map = service.initMap('map', [41.3851, 2.1734], 13);
+      const result = service.getMap();
+
+      expect(result).toBe(map);
+    });
+
+    it('should throw an error when map is not initialized', () => {
+      expect(() => service.getMap()).toThrowError('Map not initialized');
+    });
 
   });
 

--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -194,10 +194,31 @@ describe('MapService', () => {
   });
 
   describe('destroy', () => {
-  
-    it('should remove the map when initialized');
 
-    it('should not throw when map is not initialized');
+    beforeEach(() => {
+      const div = document.createElement('div');
+      div.id = 'map';
+      document.body.appendChild(div);
+    });
+
+    afterEach(() => {
+      document.getElementById('map')?.remove();
+    });
+
+    it('should remove the map when initialized', () => {
+      service.initMap('map', [41.3851, 2.1734], 13);
+
+      const map = service.getMap();
+      const removeSpy = spyOn(map, 'remove').and.callThrough();
+
+      service.destroy();
+
+      expect(removeSpy).toHaveBeenCalled();
+    });
+
+    it('should not throw when map is not initialized', () => {
+      expect(() => service.destroy()).not.toThrow();
+    });
 
   });
 

--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -130,11 +130,39 @@ describe('MapService', () => {
 
   describe('setView', () => {
 
-    it('should set the map view with provided coordinates');
+    beforeEach(() => {
+      const div = document.createElement('div');
+      div.id = 'map';
+      document.body.appendChild(div);
 
-    it('should set the map view with provided zoom');
+      service.initMap('map', [41.3851, 2.1734], 13);
+    });
 
-    it('should use default zoom when none is provided');
+    afterEach(() => {
+      document.getElementById('map')?.remove();
+      service.destroy();
+    });
+
+    it('should set the map view with provided coordinates', () => {
+      const setViewSpy = spyOn(service.getMap(), 'setView').and.callThrough();
+      service.setView([40.4168, -3.7038]);
+
+      expect(setViewSpy).toHaveBeenCalledWith([40.4168, -3.7038], 19);
+    });
+
+    it('should set the map view with provided zoom', () => {
+      const setViewSpy = spyOn(service.getMap(), 'setView').and.callThrough();
+      service.setView([40.4168, -3.7038], 15);
+
+      expect(setViewSpy).toHaveBeenCalledWith([40.4168, -3.7038], 15);
+    });
+
+    it('should use default zoom when none is provided', () => {
+      const setViewSpy = spyOn(service.getMap(), 'setView').and.callThrough();
+      service.setView([40.4168, -3.7038]);
+
+      expect(setViewSpy).toHaveBeenCalledWith([40.4168, -3.7038], 19);
+    });
 
   });
 

--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -224,13 +224,23 @@ describe('MapService', () => {
 
   describe('locationIcon', () => {
 
-    it('should initialize the location icon');
+    it('should initialize the location icon', () => {
+      expect(service.locationIcon).toBeTruthy();
+    });
 
-    it('should configure the icon urls');
+    it('should configure the icon urls', () => {
+      expect(service.locationIcon.options.iconUrl).toBe('/assets/icons/marker-icon.png');
+      expect(service.locationIcon.options.iconRetinaUrl).toBe('/assets/icons/marker-icon-2x.png');
+      expect(service.locationIcon.options.shadowUrl).toBe('/assets/icons/marker-shadow.png');
+    });
 
-    it('should configure the icon size');
+    it('should configure the icon size', () => {
+      expect(service.locationIcon.options.iconSize).toEqual([25, 40]);
+    });
 
-    it('should configure the shadow anchor');
+    it('should configure the shadow anchor', () => {
+      expect(service.locationIcon.options.shadowAnchor).toEqual([9, 19]);
+    });
 
   });
 


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/117)

## Summary  
Expanded and completed the unit test coverage for `MapService`, ensuring full validation of Leaflet map initialization, marker handling, view control, layer management, and cleanup behavior. The test suite was also refactored to reduce duplication and improve readability by extracting reusable DOM setup helpers.

## What's included  
- Added full coverage for `initMap`:
  - map initialization
  - tile layer configuration
  - correct return of map instance  
- Added full coverage for `getMap`:
  - returns initialized map correctly
  - throws error when map is not initialized  
- Added full coverage for `createMarker`:
  - default draggable behavior
  - draggable enabled/disabled states
  - correct usage of custom location icon
  - marker is added to map
  - correct marker instance creation  
- Added full coverage for `setView`:
  - updates map center with default zoom
  - updates map center with custom zoom
  - fallback to default zoom when not provided  
- Added full coverage for `removeLayer`:
  - correctly removes marker/layer from map  
- Added full coverage for `destroy`:
  - properly removes map instance
  - safely handles uninitialized map  
- Added full coverage for `locationIcon`:
  - icon initialization
  - correct icon URLs
  - correct icon size configuration
  - correct shadow anchor configuration  
- Refactored test setup:
  - extracted DOM creation into reusable helper (`createMapDom`)
  - extracted cleanup logic into reusable helper (`cleanupMapDom`)
  - reduced duplication across test suites