### PR TITLE
Refactor(vehicle-page): Improve test coverage and update HTTP testing setup (#118)

### DIFF
--- a/src/app/features/map/pages/map/map-page.spec.ts
+++ b/src/app/features/map/pages/map/map-page.spec.ts
@@ -43,21 +43,21 @@ describe('MapPageComponent', () => {
 
   });
 
-    describe('child components rendering', () => {
+  describe('child components rendering', () => {
 
-      it('should render graphics-view component', () => {
-        const graphicsComponent = fixture.nativeElement.querySelector('app-map-container');
-        expect(graphicsComponent).toBeTruthy();
-      });
-
-      it('should render GraphicsViewComponent', () => {
-        const child = fixture.debugElement.query(
-          By.directive(MapContainerComponent)
-        );
-
-        expect(child).toBeTruthy();
-      });
-
+    it('should render graphics-view component', () => {
+      const graphicsComponent = fixture.nativeElement.querySelector('app-map-container');
+      expect(graphicsComponent).toBeTruthy();
     });
+
+    it('should render GraphicsViewComponent', () => {
+      const child = fixture.debugElement.query(
+        By.directive(MapContainerComponent)
+      );
+
+      expect(child).toBeTruthy();
+    });
+
+  });
 
 });

--- a/src/app/features/vehicle/pages/vehicle/vehicle-page.spec.ts
+++ b/src/app/features/vehicle/pages/vehicle/vehicle-page.spec.ts
@@ -42,11 +42,15 @@ describe('VehiclePageComponent', () => {
   describe('Child components rendering', () => {
 
     it('should render app-vehicle-view element', () => {
+      const vehicleViewComponent = fixture.nativeElement.querySelector('app-vehicle-view');
 
+      expect(vehicleViewComponent).toBeTruthy();
     });
 
     it('should render VehicleViewComponent', () => {
-
+      const child = fixture.debugElement.query(By.directive(VehicleViewComponent));
+      
+      expect(child).toBeTruthy();
     });
 
   });

--- a/src/app/features/vehicle/pages/vehicle/vehicle-page.spec.ts
+++ b/src/app/features/vehicle/pages/vehicle/vehicle-page.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { HttpClientModule } from '@angular/common/http';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Auth } from '@angular/fire/auth';
 
 import { VehiclePageComponent } from './vehicle-page';
@@ -17,9 +18,11 @@ describe('VehiclePageComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [VehiclePageComponent, HttpClientModule],
+      imports: [VehiclePageComponent],
       providers: [
-        { provide: Auth, useValue: authMock }
+        { provide: Auth, useValue: authMock },
+        provideHttpClient(),
+        provideHttpClientTesting()
       ]
     }).compileComponents();
 

--- a/src/app/features/vehicle/pages/vehicle/vehicle-page.spec.ts
+++ b/src/app/features/vehicle/pages/vehicle/vehicle-page.spec.ts
@@ -1,9 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Auth } from '@angular/fire/auth';
 
 import { VehiclePageComponent } from './vehicle-page';
+import { VehicleViewComponent } from '../../components/vehicle-view/vehicle-view';
 
 describe('VehiclePageComponent', () => {
   let component: VehiclePageComponent;
@@ -37,11 +39,16 @@ describe('VehiclePageComponent', () => {
     });
   });
 
-  describe('Template rendering', () => {
-    it('should render vehicle view component', () => {
-      const vehicleViewComponent = fixture.nativeElement.querySelector('app-vehicle-view');
-      expect(vehicleViewComponent).toBeTruthy();
+  describe('Child components rendering', () => {
+
+    it('should render app-vehicle-view element', () => {
+
     });
+
+    it('should render VehicleViewComponent', () => {
+
+    });
+
   });
 
 });

--- a/src/app/features/vehicle/pages/vehicle/vehicle-page.spec.ts
+++ b/src/app/features/vehicle/pages/vehicle/vehicle-page.spec.ts
@@ -34,9 +34,11 @@ describe('VehiclePageComponent', () => {
   });
 
   describe('Component creation', () => {
+
     it('should create', () => {
       expect(component).toBeTruthy();
     });
+
   });
 
   describe('Child components rendering', () => {


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/118)

## Summary

Improved `VehiclePageComponent` test coverage by validating the rendering of `VehicleViewComponent` and updated the HTTP testing configuration to use the recommended provider-based APIs instead of the deprecated testing module.

## What's included

* Added test to verify `VehicleViewComponent` is rendered through Angular's component tree using `By.directive`
* Kept DOM-level validation for `app-vehicle-view` rendering
* Replaced deprecated `HttpClientTestingModule`
* Added `provideHttpClient`
* Added `provideHttpClientTesting`
* Updated TestBed configuration to use provider-based HTTP testing setup
* Preserved existing `Auth` mock configuration required by child component dependencies
* Improved test reliability by validating component instantiation rather than only DOM presence
* Improved test file readability with consistent spacing and formatting