### PR TITLE
test(vehicle-view): add full test coverage for filtering and user management (#119)

### DIFF
--- a/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
@@ -74,12 +74,15 @@ describe('VehicleViewComponent', () => {
   });
 
   describe('Component creation', () => {
+
     it('should create', () => {
       expect(component).toBeTruthy();
     });
+
   });
 
   describe('Initial state', () => {
+
     it('should expose the vehicle list from VehicleService', () => {
       expect(component.vehicleList).toBe(vehicleServiceMock.vehicles);
     });
@@ -96,9 +99,11 @@ describe('VehicleViewComponent', () => {
       expect(component.confirmMsg.deleteVehicle.title).toBe('Delete vehicle?');
       expect(component.confirmMsg.deleteVehicle.message).toBe('Are you sure you want to delete this vehicle? This action cannot be undone.');
     });
+
   });
 
   describe('Save vehicle', () => {
+
     it('should keep provided location when vehicle already has location', async () => {
       const vehicleMock: VehicleInterface = {
         name: 'Ferrari',
@@ -247,9 +252,11 @@ describe('VehicleViewComponent', () => {
 
       expect(VehicleModalServiceMock.close).toHaveBeenCalled();
     });
+
   });
 
   describe('Delete vehicle', () => {
+
     it('should delete vehicle when confirmed', () => {
       const vehicleMock: VehicleInterface = {
         _id: '123',
@@ -288,6 +295,7 @@ describe('VehicleViewComponent', () => {
 
       expect(VehicleModalServiceMock.close).toHaveBeenCalled();
     });
+
   });
 
   describe('Template rendering', () => {
@@ -341,6 +349,7 @@ describe('VehicleViewComponent', () => {
     it('should render user management modal when user management modal is open', () => {
 
     });
+
   });
 
   describe('Filter vehicles', () => {
@@ -543,4 +552,5 @@ describe('VehicleViewComponent', () => {
     });
 
   });
+
 });

--- a/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
@@ -12,7 +12,10 @@ import { VehicleModalState } from '../../enums/vehicle-modal-state.enum';
 
 const authMock = {
   isLoggedIn: jasmine.createSpy('isLoggedIn').and.returnValue(true),
-  getUser: jasmine.createSpy('getUser').and.returnValue({ name: 'JordiTheBest', role: 'admin' })
+  getUser: jasmine.createSpy('getUser').and.returnValue({ name: 'JordiTheBest', role: 'admin' }),
+  currentUser: { 
+    uid: 'JordiTheBest' 
+  } as { uid: string } | null
 };
 
 const vehicleServiceMock = {
@@ -40,6 +43,20 @@ const geolocationServiceMock = {
   getCurrentLocation: jasmine.createSpy('getCurrentLocation')
 };
 
+const vehicleMock: VehicleInterface = {
+  _id: '123',
+  name: 'Ferrari',
+  model: 'F8',
+  plate: '12345XC',
+  location: { lat: 10, lng: 20 }
+};
+
+const vehicleWithoutLocationMock: VehicleInterface = {
+  name: 'Ferrari',
+  model: 'F8',
+  plate: '12345XC'
+};
+
 describe('VehicleViewComponent', () => {
   let component: VehicleViewComponent;
   let fixture: ComponentFixture<VehicleViewComponent>;
@@ -49,14 +66,19 @@ describe('VehicleViewComponent', () => {
     vehicleServiceMock.addVehicles.calls.reset();
     vehicleServiceMock.updateVehicle.calls.reset();
     vehicleServiceMock.deleteVehicle.calls.reset();
+    vehicleServiceMock.addUserToVehicle.calls.reset();
+    vehicleServiceMock.removeUserFromVehicle.calls.reset();
     VehicleModalServiceMock.openCreate.calls.reset();
     VehicleModalServiceMock.close.calls.reset();
     VehicleModalServiceMock.openConfirmDelete.calls.reset();
     geolocationServiceMock.getCurrentLocation.calls.reset();
-    
+
     VehicleModalServiceMock.selectedVehicle.set(null);
     VehicleModalServiceMock.formMode.set('create');
     VehicleModalServiceMock.activeModal.set(VehicleModalState.Closed);
+    authMock.currentUser = { 
+      uid: 'JordiTheBest' 
+    };
 
     await TestBed.configureTestingModule({
       imports: [VehicleViewComponent],
@@ -105,84 +127,47 @@ describe('VehicleViewComponent', () => {
   describe('Save vehicle', () => {
 
     it('should keep provided location when vehicle already has location', async () => {
-      const vehicleMock: VehicleInterface = {
-        name: 'Ferrari',
-        model: 'F8',
-        plate: '12345XC',
-        location: { lat: 10, lng: 20 }
-      };
-
       VehicleModalServiceMock.formMode.set('create');
-      geolocationServiceMock.getCurrentLocation.calls.reset();
+
       await component.saveVehicle(vehicleMock);
 
       expect(geolocationServiceMock.getCurrentLocation).not.toHaveBeenCalled();
     });
 
     it('should get geolocation when creating vehicle without location', async () => {
-      const vehicleMock: VehicleInterface = {
-        name: 'Ferrari',
-        model: 'F8',
-        plate: '12345XC'
-      };
-
       VehicleModalServiceMock.formMode.set('create');
       geolocationServiceMock.getCurrentLocation.and.returnValue(Promise.resolve([41.5, 2.3]));
 
-      await component.saveVehicle(vehicleMock);
+      await component.saveVehicle(vehicleWithoutLocationMock);
 
       expect(geolocationServiceMock.getCurrentLocation).toHaveBeenCalled();
       expect(vehicleServiceMock.addVehicles).toHaveBeenCalledWith({
-        name: 'Ferrari',
-        model: 'F8',
-        plate: '12345XC',
+        ...vehicleWithoutLocationMock,
         location: { lat: 41.5, lng: 2.3 }
       });
     });
 
     it('should use fallback location when geolocation fails on create', async () => {
-      const vehicleMock: VehicleInterface = {
-        name: 'Ferrari',
-        model: 'F8',
-        plate: '12345XC'
-      };
-
       VehicleModalServiceMock.formMode.set('create');
       geolocationServiceMock.getCurrentLocation.and.returnValue(Promise.reject('error'));
 
-      await component.saveVehicle(vehicleMock);
+      await component.saveVehicle(vehicleWithoutLocationMock);
 
       expect(vehicleServiceMock.addVehicles).toHaveBeenCalledWith({
-        name: 'Ferrari',
-        model: 'F8',
-        plate: '12345XC',
+        ...vehicleWithoutLocationMock,
         location: { lat: 41.402, lng: 2.194 }
       });
     });
 
     it('should call addVehicles when mode is create', async () => {
-      const vehicleMock: VehicleInterface = {
-        name: 'Ferrari',
-        model: 'F8',
-        plate: '12345XC',
-        location: { lat: 10, lng: 20 }
-      };
-
       VehicleModalServiceMock.formMode.set('create');
+
       await component.saveVehicle(vehicleMock);
 
       expect(vehicleServiceMock.addVehicles).toHaveBeenCalledWith(vehicleMock);
     });
 
     it('should call updateVehicle when mode is edit', async () => {
-      const originalVehicle: VehicleInterface = {
-        _id: '123',
-        name: 'Ferrari',
-        model: 'F8',
-        plate: '12345XC',
-        location: { lat: 10, lng: 20 }
-      };
-
       const updatedData: VehicleInterface = {
         name: 'Lamborghini',
         model: 'Aventador',
@@ -190,26 +175,17 @@ describe('VehicleViewComponent', () => {
       };
 
       VehicleModalServiceMock.formMode.set('edit');
-      VehicleModalServiceMock.selectedVehicle.set(originalVehicle);
+      VehicleModalServiceMock.selectedVehicle.set(vehicleMock);
 
       await component.saveVehicle(updatedData);
 
-      expect(vehicleServiceMock.updateVehicle).toHaveBeenCalledWith(originalVehicle, {
-        name: 'Lamborghini',
-        model: 'Aventador',
-        plate: '54321AB',
-        location: { lat: 10, lng: 20 }
+      expect(vehicleServiceMock.updateVehicle).toHaveBeenCalledWith(vehicleMock, {
+        ...updatedData,
+        location: vehicleMock.location
       });
     });
 
     it('should preserve original location when editing', async () => {
-      const originalVehicle: VehicleInterface = {
-        _id: '123',
-        name: 'Ferrari',
-        model: 'F8',
-        plate: '12345XC',
-        location: { lat: 10, lng: 20 }
-      };
 
       const updatedData: VehicleInterface = {
         name: 'Ferrari',
@@ -218,37 +194,27 @@ describe('VehicleViewComponent', () => {
       };
 
       VehicleModalServiceMock.formMode.set('edit');
-      VehicleModalServiceMock.selectedVehicle.set(originalVehicle);
+      VehicleModalServiceMock.selectedVehicle.set(vehicleMock);
 
       await component.saveVehicle(updatedData);
 
       const callArgs = vehicleServiceMock.updateVehicle.calls.mostRecent().args;
-      expect(callArgs[1].location).toEqual({ lat: 10, lng: 20 });
+      expect(callArgs[1].location).toEqual(vehicleMock.location);
     });
 
     it('should not update vehicle if no original vehicle is selected', async () => {
-      const updatedData: VehicleInterface = {
-        name: 'Ferrari',
-        model: 'F8',
-        plate: '12345XC'
-      };
-
       VehicleModalServiceMock.formMode.set('edit');
       VehicleModalServiceMock.selectedVehicle.set(null);
 
-      await component.saveVehicle(updatedData);
+      await component.saveVehicle(vehicleWithoutLocationMock);
 
       expect(vehicleServiceMock.updateVehicle).not.toHaveBeenCalled();
     });
 
     it('should close the vehicle modal after saving', async () => {
-      const vehicle: VehicleInterface = {
-        name: 'Ferrari',
-        model: '488',
-        plate: '3333CCC'
-      };
       VehicleModalServiceMock.formMode.set('create');
-      await component.saveVehicle(vehicle);
+
+      await component.saveVehicle(vehicleWithoutLocationMock);
 
       expect(VehicleModalServiceMock.close).toHaveBeenCalled();
     });
@@ -258,16 +224,7 @@ describe('VehicleViewComponent', () => {
   describe('Delete vehicle', () => {
 
     it('should delete vehicle when confirmed', () => {
-      const vehicleMock: VehicleInterface = {
-        _id: '123',
-        name: 'Ferrari',
-        model: 'F8',
-        plate: '12345XC',
-        location: { lat: 10, lng: 20 }
-      };
-
       VehicleModalServiceMock.selectedVehicle.set(vehicleMock);
-
       component.confirmDeleteVehicle();
 
       expect(vehicleServiceMock.deleteVehicle).toHaveBeenCalledWith(vehicleMock);
@@ -275,22 +232,13 @@ describe('VehicleViewComponent', () => {
 
     it('should not delete if no vehicle is selected', () => {
       VehicleModalServiceMock.selectedVehicle.set(null);
-
       component.confirmDeleteVehicle();
 
       expect(vehicleServiceMock.deleteVehicle).not.toHaveBeenCalled();
     });
 
     it('should close modal after deleting', () => {
-      const vehicleMock: VehicleInterface = {
-        _id: '123',
-        name: 'Ferrari',
-        model: 'F8',
-        plate: '12345XC'
-      };
-
       VehicleModalServiceMock.selectedVehicle.set(vehicleMock);
-
       component.confirmDeleteVehicle();
 
       expect(VehicleModalServiceMock.close).toHaveBeenCalled();
@@ -301,7 +249,7 @@ describe('VehicleViewComponent', () => {
   describe('Template rendering', () => {
 
     it('should render vehicle table when vehicle list is not empty', () => {
-      vehicleServiceMock.vehicles.set([ 
+      vehicleServiceMock.vehicles.set([
         { name: 'Lamborghini', model: 'Aventador', plate: 'LMB2026' },
         { name: 'Ferrari', model: 'F8 Tributo', plate: 'F8X2019' }
       ]);
@@ -425,13 +373,6 @@ describe('VehicleViewComponent', () => {
 
   describe('Add user to vehicle', () => {
 
-    const vehicleMock: VehicleInterface = {
-      _id: '123',
-      name: 'Ferrari',
-      model: 'F8',
-      plate: '12345XC'
-    };
-
     it('should set selectedVehicle and open user management modal', () => {
       component.openAddUserModal(vehicleMock);
 
@@ -440,8 +381,7 @@ describe('VehicleViewComponent', () => {
     });
 
     it('should call addUserToVehicle on VehicleService', () => {
-      vehicleServiceMock.addUserToVehicle = jasmine.createSpy('addUserToVehicle')
-        .and.returnValue({ subscribe: ({ next }: any) => next() });
+      vehicleServiceMock.addUserToVehicle.and.returnValue({ subscribe: ({ next }: any) => next() });
 
       component.selectedVehicle.set(vehicleMock);
       component.addUserToVehicle('test@test.com');
@@ -450,8 +390,7 @@ describe('VehicleViewComponent', () => {
     });
 
     it('should reset modal and close on success', () => {
-      vehicleServiceMock.addUserToVehicle = jasmine.createSpy('addUserToVehicle')
-        .and.returnValue({ subscribe: ({ next }: any) => next() });
+      vehicleServiceMock.addUserToVehicle.and.returnValue({ subscribe: ({ next }: any) => next() });
 
       const resetSpy = jasmine.createSpy('resetModal');
       component['userModal'] = { resetModal: resetSpy, setError: jasmine.createSpy('setError') } as any;
@@ -465,8 +404,7 @@ describe('VehicleViewComponent', () => {
 
     it('should set error message on user modal when request fails', () => {
       const errorResponse = { error: { message: 'User already added' } };
-      vehicleServiceMock.addUserToVehicle = jasmine.createSpy('addUserToVehicle')
-        .and.returnValue({ subscribe: ({ error }: any) => error(errorResponse) });
+      vehicleServiceMock.addUserToVehicle.and.returnValue({ subscribe: ({ error }: any) => error(errorResponse) });
 
       const setErrorSpy = jasmine.createSpy('setError');
       component['userModal'] = { resetModal: jasmine.createSpy('resetModal'), setError: setErrorSpy } as any;
@@ -490,16 +428,8 @@ describe('VehicleViewComponent', () => {
 
   describe('Remove user from vehicle', () => {
 
-    const vehicleMock: VehicleInterface = {
-      _id: '123',
-      name: 'Ferrari',
-      model: 'F8',
-      plate: '12345XC'
-    };
-
     it('should call removeUserFromVehicle on VehicleService', () => {
-      vehicleServiceMock.removeUserFromVehicle = jasmine.createSpy('removeUserFromVehicle')
-        .and.returnValue({ subscribe: ({ next }: any) => next() });
+      vehicleServiceMock.removeUserFromVehicle.and.returnValue({ subscribe: ({ next }: any) => next() });
 
       component.selectedVehicle.set(vehicleMock);
       component.removeUserFromVehicle('user-1');
@@ -508,11 +438,8 @@ describe('VehicleViewComponent', () => {
     });
 
     it('should close modal when removed user is current user', () => {
-      vehicleServiceMock.removeUserFromVehicle = jasmine.createSpy('removeUserFromVehicle')
-        .and.returnValue({ subscribe: ({ next }: any) => next() });
-
-      authMock.getUser.and.returnValue({ name: 'JordiTheBest', role: 'admin' });
-      (authMock as any).currentUser = { uid: 'user-1' };
+      vehicleServiceMock.removeUserFromVehicle.and.returnValue({ subscribe: ({ next }: any) => next() });
+      authMock.currentUser = { uid: 'user-1' };
 
       component.selectedVehicle.set(vehicleMock);
       component.removeUserFromVehicle('user-1');
@@ -523,11 +450,8 @@ describe('VehicleViewComponent', () => {
     it('should update selectedVehicle when removed user is not current user', () => {
       const updatedVehicle: VehicleInterface = { ...vehicleMock, name: 'Ferrari Updated' };
       vehicleServiceMock.vehicles.set([updatedVehicle]);
-
-      vehicleServiceMock.removeUserFromVehicle = jasmine.createSpy('removeUserFromVehicle')
-        .and.returnValue({ subscribe: ({ next }: any) => next() });
-
-      (authMock as any).currentUser = { uid: 'someone-else' };
+      vehicleServiceMock.removeUserFromVehicle.and.returnValue({ subscribe: ({ next }: any) => next() });
+      authMock.currentUser = { uid: 'someone-else' };
 
       component.selectedVehicle.set(vehicleMock);
       component.removeUserFromVehicle('user-2');
@@ -537,8 +461,7 @@ describe('VehicleViewComponent', () => {
 
     it('should log error when request fails', () => {
       const consoleSpy = spyOn(console, 'error');
-      vehicleServiceMock.removeUserFromVehicle = jasmine.createSpy('removeUserFromVehicle')
-        .and.returnValue({ subscribe: ({ error }: any) => error('failed') });
+      vehicleServiceMock.removeUserFromVehicle.and.returnValue({ subscribe: ({ error }: any) => error('failed') });
 
       component.selectedVehicle.set(vehicleMock);
       component.removeUserFromVehicle('user-1');

--- a/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
@@ -20,7 +20,8 @@ const vehicleServiceMock = {
   loadVehicles: jasmine.createSpy('loadVehicles'),
   addVehicles: jasmine.createSpy('addVehicles'),
   updateVehicle: jasmine.createSpy('updateVehicle'),
-  deleteVehicle: jasmine.createSpy('deleteVehicle')
+  deleteVehicle: jasmine.createSpy('deleteVehicle'),
+  addUserToVehicle: jasmine.createSpy('addUserToVehicle'),
 };
 
 const VehicleModalServiceMock = {
@@ -410,15 +411,66 @@ describe('VehicleViewComponent', () => {
 
   describe('Add user to vehicle', () => {
 
-    it('should set selectedVehicle and open user management modal');
+    const vehicleMock: VehicleInterface = {
+      _id: '123',
+      name: 'Ferrari',
+      model: 'F8',
+      plate: '12345XC'
+    };
 
-    it('should call addUserToVehicle on VehicleService');
+    it('should set selectedVehicle and open user management modal', () => {
+      component.openAddUserModal(vehicleMock);
 
-    it('should reset modal and close on success');
+      expect(component.selectedVehicle()).toEqual(vehicleMock);
+      expect(VehicleModalServiceMock.activeModal()).toBe(VehicleModalState.UserManagement);
+    });
 
-    it('should set error message on user modal when request fails');
+    it('should call addUserToVehicle on VehicleService', () => {
+      vehicleServiceMock.addUserToVehicle = jasmine.createSpy('addUserToVehicle')
+        .and.returnValue({ subscribe: ({ next }: any) => next() });
 
-    it('should not call service if no vehicle is selected');
+      component.selectedVehicle.set(vehicleMock);
+      component.addUserToVehicle('test@test.com');
+
+      expect(vehicleServiceMock.addUserToVehicle).toHaveBeenCalledWith('123', 'test@test.com');
+    });
+
+    it('should reset modal and close on success', () => {
+      vehicleServiceMock.addUserToVehicle = jasmine.createSpy('addUserToVehicle')
+        .and.returnValue({ subscribe: ({ next }: any) => next() });
+
+      const resetSpy = jasmine.createSpy('resetModal');
+      component['userModal'] = { resetModal: resetSpy, setError: jasmine.createSpy('setError') } as any;
+
+      component.selectedVehicle.set(vehicleMock);
+      component.addUserToVehicle('test@test.com');
+
+      expect(resetSpy).toHaveBeenCalled();
+      expect(VehicleModalServiceMock.activeModal()).toBe(VehicleModalState.Closed);
+    });
+
+    it('should set error message on user modal when request fails', () => {
+      const errorResponse = { error: { message: 'User already added' } };
+      vehicleServiceMock.addUserToVehicle = jasmine.createSpy('addUserToVehicle')
+        .and.returnValue({ subscribe: ({ error }: any) => error(errorResponse) });
+
+      const setErrorSpy = jasmine.createSpy('setError');
+      component['userModal'] = { resetModal: jasmine.createSpy('resetModal'), setError: setErrorSpy } as any;
+
+      component.selectedVehicle.set(vehicleMock);
+      component.addUserToVehicle('test@test.com');
+
+      expect(setErrorSpy).toHaveBeenCalledWith('User already added');
+    });
+
+    it('should not call service if no vehicle is selected', () => {
+      vehicleServiceMock.addUserToVehicle = jasmine.createSpy('addUserToVehicle');
+
+      component.selectedVehicle.set(null);
+      component.addUserToVehicle('test@test.com');
+
+      expect(vehicleServiceMock.addUserToVehicle).not.toHaveBeenCalled();
+    });
 
   });
 

--- a/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
@@ -343,19 +343,68 @@ describe('VehicleViewComponent', () => {
 
   describe('Filter vehicles', () => {
 
-    it('should call onFilterChange and update filterState');
+    beforeEach(() => {
+      vehicleServiceMock.vehicles.set([
+        { _id: '1', name: 'Ferrari', model: 'F8', plate: '12345XC' },
+        { _id: '2', name: 'Lamborghini', model: 'Aventador', plate: 'LMB2026' },
+        { _id: '3', name: 'Pagani', model: 'Huayra', plate: 'PAG0001' }
+      ]);
+    });
 
-    it('should filter vehicles by name');
+    it('should call onFilterChange and update filterState', () => {
+      const newState = { query: 'ferrari', sortField: 'name' as const, sortDir: 'asc' as const };
 
-    it('should filter vehicles by model');
+      component.onFilterChange(newState);
 
-    it('should filter vehicles by plate');
+      expect(component.filterState()).toEqual(newState);
+    });
 
-    it('should return all vehicles when query is empty');
+    it('should filter vehicles by name', () => {
+      component.onFilterChange({ query: 'ferrari', sortField: 'name', sortDir: 'asc' });
 
-    it('should sort vehicles ascending by default field');
+      const result = component.filteredVehicles();
+      expect(result.length).toBe(1);
+      expect(result[0].name).toBe('Ferrari');
+    });
 
-    it('should sort vehicles descending when sortDir is desc');
+    it('should filter vehicles by model', () => {
+      component.onFilterChange({ query: 'aventador', sortField: 'name', sortDir: 'asc' });
+
+      const result = component.filteredVehicles();
+      expect(result.length).toBe(1);
+      expect(result[0].model).toBe('Aventador');
+    });
+
+    it('should filter vehicles by plate', () => {
+      component.onFilterChange({ query: 'pag0001', sortField: 'name', sortDir: 'asc' });
+
+      const result = component.filteredVehicles();
+      expect(result.length).toBe(1);
+      expect(result[0].plate).toBe('PAG0001');
+    });
+
+    it('should return all vehicles when query is empty', () => {
+      component.onFilterChange({ query: '', sortField: 'name', sortDir: 'asc' });
+
+      const result = component.filteredVehicles();
+      expect(result.length).toBe(3);
+    });
+
+    it('should sort vehicles ascending by default field', () => {
+      component.onFilterChange({ query: '', sortField: 'name', sortDir: 'asc' });
+
+      const result = component.filteredVehicles();
+      expect(result[0].name).toBe('Ferrari');
+      expect(result[2].name).toBe('Pagani');
+    });
+
+    it('should sort vehicles descending when sortDir is desc', () => {
+      component.onFilterChange({ query: '', sortField: 'name', sortDir: 'desc' });
+
+      const result = component.filteredVehicles();
+      expect(result[0].name).toBe('Pagani');
+      expect(result[2].name).toBe('Ferrari');
+    });
 
   });
 

--- a/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
@@ -22,6 +22,7 @@ const vehicleServiceMock = {
   updateVehicle: jasmine.createSpy('updateVehicle'),
   deleteVehicle: jasmine.createSpy('deleteVehicle'),
   addUserToVehicle: jasmine.createSpy('addUserToVehicle'),
+  removeUserFromVehicle: jasmine.createSpy('removeUserFromVehicle'),
 };
 
 const VehicleModalServiceMock = {
@@ -476,15 +477,70 @@ describe('VehicleViewComponent', () => {
 
   describe('Remove user from vehicle', () => {
 
-    it('should call removeUserFromVehicle on VehicleService');
+    const vehicleMock: VehicleInterface = {
+      _id: '123',
+      name: 'Ferrari',
+      model: 'F8',
+      plate: '12345XC'
+    };
 
-    it('should close modal when removed user is current user');
+    it('should call removeUserFromVehicle on VehicleService', () => {
+      vehicleServiceMock.removeUserFromVehicle = jasmine.createSpy('removeUserFromVehicle')
+        .and.returnValue({ subscribe: ({ next }: any) => next() });
 
-    it('should update selectedVehicle when removed user is not current user');
+      component.selectedVehicle.set(vehicleMock);
+      component.removeUserFromVehicle('user-1');
 
-    it('should log error when request fails');
+      expect(vehicleServiceMock.removeUserFromVehicle).toHaveBeenCalledWith('123', 'user-1');
+    });
 
-    it('should not call service if no vehicle is selected');
+    it('should close modal when removed user is current user', () => {
+      vehicleServiceMock.removeUserFromVehicle = jasmine.createSpy('removeUserFromVehicle')
+        .and.returnValue({ subscribe: ({ next }: any) => next() });
+
+      authMock.getUser.and.returnValue({ name: 'JordiTheBest', role: 'admin' });
+      (authMock as any).currentUser = { uid: 'user-1' };
+
+      component.selectedVehicle.set(vehicleMock);
+      component.removeUserFromVehicle('user-1');
+
+      expect(VehicleModalServiceMock.close).toHaveBeenCalled();
+    });
+
+    it('should update selectedVehicle when removed user is not current user', () => {
+      const updatedVehicle: VehicleInterface = { ...vehicleMock, name: 'Ferrari Updated' };
+      vehicleServiceMock.vehicles.set([updatedVehicle]);
+
+      vehicleServiceMock.removeUserFromVehicle = jasmine.createSpy('removeUserFromVehicle')
+        .and.returnValue({ subscribe: ({ next }: any) => next() });
+
+      (authMock as any).currentUser = { uid: 'someone-else' };
+
+      component.selectedVehicle.set(vehicleMock);
+      component.removeUserFromVehicle('user-2');
+
+      expect(component.selectedVehicle()).toEqual(updatedVehicle);
+    });
+
+    it('should log error when request fails', () => {
+      const consoleSpy = spyOn(console, 'error');
+      vehicleServiceMock.removeUserFromVehicle = jasmine.createSpy('removeUserFromVehicle')
+        .and.returnValue({ subscribe: ({ error }: any) => error('failed') });
+
+      component.selectedVehicle.set(vehicleMock);
+      component.removeUserFromVehicle('user-1');
+
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+
+    it('should not call service if no vehicle is selected', () => {
+      vehicleServiceMock.removeUserFromVehicle = jasmine.createSpy('removeUserFromVehicle');
+
+      component.selectedVehicle.set(null);
+      component.removeUserFromVehicle('user-1');
+
+      expect(vehicleServiceMock.removeUserFromVehicle).not.toHaveBeenCalled();
+    });
 
   });
 });

--- a/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
@@ -335,5 +335,55 @@ describe('VehicleViewComponent', () => {
       const confirmModalElement = fixture.nativeElement.querySelector('app-confirm-modal');
       expect(confirmModalElement).toBeTruthy();
     });
+
+    it('should render user management modal when user management modal is open', () => {
+
+    });
+  });
+
+  describe('Filter vehicles', () => {
+
+    it('should call onFilterChange and update filterState');
+
+    it('should filter vehicles by name');
+
+    it('should filter vehicles by model');
+
+    it('should filter vehicles by plate');
+
+    it('should return all vehicles when query is empty');
+
+    it('should sort vehicles ascending by default field');
+
+    it('should sort vehicles descending when sortDir is desc');
+
+  });
+
+  describe('Add user to vehicle', () => {
+
+    it('should set selectedVehicle and open user management modal');
+
+    it('should call addUserToVehicle on VehicleService');
+
+    it('should reset modal and close on success');
+
+    it('should set error message on user modal when request fails');
+
+    it('should not call service if no vehicle is selected');
+
+  });
+
+  describe('Remove user from vehicle', () => {
+
+    it('should call removeUserFromVehicle on VehicleService');
+
+    it('should close modal when removed user is current user');
+
+    it('should update selectedVehicle when removed user is not current user');
+
+    it('should log error when request fails');
+
+    it('should not call service if no vehicle is selected');
+
   });
 });

--- a/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
@@ -149,7 +149,7 @@ describe('VehicleViewComponent', () => {
 
     it('should use fallback location when geolocation fails on create', async () => {
       VehicleModalServiceMock.formMode.set('create');
-      geolocationServiceMock.getCurrentLocation.and.returnValue(Promise.reject('error'));
+      geolocationServiceMock.getCurrentLocation.and.returnValue(Promise.reject(new Error('geolocation failed')));
 
       await component.saveVehicle(vehicleWithoutLocationMock);
 

--- a/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
@@ -347,7 +347,11 @@ describe('VehicleViewComponent', () => {
     });
 
     it('should render user management modal when user management modal is open', () => {
+      VehicleModalServiceMock.activeModal.set(VehicleModalState.UserManagement);
+      fixture.detectChanges();
 
+      const userModalElement = fixture.nativeElement.querySelector('app-manage-vehicle-users-modal');
+      expect(userModalElement).toBeTruthy();
     });
 
   });


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/pull/119)

### Description
Extend the existing test suite for `VehicleViewComponent` to cover the vehicle filtering logic and the user management flow (add/remove user from vehicle), which were previously untested. Also extracted shared mocks to reduce duplication.

---

### Acceptance Criteria
- [x] All tests pass consistently.
- [x] `filteredVehicles` computed is tested covering filtering by name, model and plate, and sorting in both directions.
- [x] `onFilterChange` is tested.
- [x] `openAddUserModal` is tested.
- [x] `addUserToVehicle` is tested covering success, error and missing vehicle cases.
- [x] `removeUserFromVehicle` is tested covering current user removal, other user removal, error and missing vehicle cases.
- [x] Added template test for the user management modal rendering.
- [x] Extracted shared `vehicleMock` and `vehicleWithoutLocationMock` to avoid repeated inline definitions.
- [x] Reset all service spies in `beforeEach` to avoid state leaking between tests.

---

### Notes
- No production code changes.
- Promise rejections now use proper `Error` instances instead of plain strings to follow best practices.