### PR TITLE
test(vehicle-service): add full test coverage and extracted shared mocks (#127)

### DIFF
--- a/src/app/features/vehicle/data-access/vehicle-service.spec.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.spec.ts
@@ -6,21 +6,42 @@ import { Auth } from '@angular/fire/auth';
 import { VehicleService } from './vehicle-service';
 import { VehicleInterface } from '../interfaces/vehicle/vehicle';
 
+const API_URL = 'http://localhost:3000/vehicles';
+
+const ferrariMock: VehicleInterface = {
+  _id: '1', 
+  name: 'Ferrari', 
+  model: 'F8 Tributo', 
+  plate: 'F123', 
+  location: { 
+    lat: 41, 
+    lng: 2 
+  }
+};
+
+const paganiMock: VehicleInterface = {
+  _id: '2',
+  name: 'Pagani',
+  model: 'Huayra',
+  plate: 'P456',
+  location: {
+    lat: 42,
+    lng: 3
+  }
+};
+
+const vehiclesMock: VehicleInterface[] = [ferrariMock, paganiMock];
+
+const authMock = {
+  currentUser: {
+    uid: 'JordiTheBest',
+    getIdToken: () => Promise.resolve('Mytoken')
+  }
+};
+
 describe('VehicleService', () => {
   let service: VehicleService;
   let httpMock: HttpTestingController;
-
-  const vehiclesMock: VehicleInterface[] = [
-    { _id: '1', name: 'Ferrari', model: 'F8 Tributo', plate: 'F123', location: { lat: 41, lng: 2 } },
-    { _id: '2', name: 'Pagani', model: 'Huayra', plate: 'P456', location: { lat: 42, lng: 3 } }
-  ];
-
-  const authMock = {
-    currentUser: {
-      uid: 'JordiTheBest',
-      getIdToken: () => Promise.resolve('Mytoken')
-    }
-  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -38,6 +59,10 @@ describe('VehicleService', () => {
     httpMock.verify();
   });
 
+  function loadMockVehicles(vehicles: VehicleInterface[] = vehiclesMock): void {
+    service.vehicles.set(vehicles);
+  }
+
   describe('Service creation', () => {
 
     it('should be created', () => {
@@ -51,35 +76,34 @@ describe('VehicleService', () => {
     it('should initialize vehicles signal as empty array', () => {
       expect(service.vehicles()).toEqual([]);
     });
+
   });
 
   describe('loadVehicles', () => {
+
     it('should call GET /vehicles endpoint', () => {
       service.loadVehicles();
 
-      const req = httpMock.expectOne('http://localhost:3000/vehicles');
-
+      const req = httpMock.expectOne(API_URL);
       expect(req.request.method).toBe('GET');
+
       req.flush([]);
     });
 
     it('should update vehicles signal with response data', () => {
       service.loadVehicles();
 
-      const req = httpMock.expectOne('http://localhost:3000/vehicles');
-      expect(req.request.method).toBe('GET');
-
+      const req = httpMock.expectOne(API_URL);
       req.flush(vehiclesMock);
 
       expect(service.vehicles()).toEqual(vehiclesMock);
     });
 
     it('should not modify vehicles when request fails', () => {
-      service.vehicles.set(vehiclesMock);
+      loadMockVehicles();
       service.loadVehicles();
 
-      const req = httpMock.expectOne('http://localhost:3000/vehicles');
-
+      const req = httpMock.expectOne(API_URL);
       req.flush(
         { message: 'Server error' },
         { status: 500, statusText: 'Internal Server Error' }
@@ -93,42 +117,17 @@ describe('VehicleService', () => {
   describe('addVehicles', () => {
 
     it('should call POST /vehicles endpoint with vehicle payload', () => {
-      const vehicle: VehicleInterface = {
-        _id: '1',
-        name: 'Lamborghini',
-        model: 'Huracan',
-        plate: 'L456',
-        location: {
-          lat: 42,
-          lng: 3
-        }
-      };
+      service.addVehicles(ferrariMock);
 
-      service.addVehicles(vehicle);
-
-      const req = httpMock.expectOne('http://localhost:3000/vehicles');
-
+      const req = httpMock.expectOne(API_URL);
       expect(req.request.method).toBe('POST');
-      expect(req.request.body).toEqual(vehicle);
+      expect(req.request.body).toEqual(ferrariMock);
 
-      req.flush({ ...vehicle, _id: '1' });
+      req.flush(ferrariMock);
     });
 
     it('should append created vehicle returned by backend to vehicles signal', () => {
-
-      const vehicleList: VehicleInterface[] = [
-        {
-          _id: '1',
-          name: 'Lamborghini',
-          model: 'Huracan',
-          plate: 'L456',
-          location: {
-            lat: 42,
-            lng: 3
-          }
-        }
-      ];
-      service.vehicles.set(vehicleList);
+      loadMockVehicles([ferrariMock]);
 
       const newVehicle: VehicleInterface = {
         name: 'Pagani',
@@ -142,22 +141,13 @@ describe('VehicleService', () => {
 
       service.addVehicles(newVehicle);
 
-      const req = httpMock.expectOne('http://localhost:3000/vehicles');
-
-      expect(req.request.method).toBe('POST');
+      const req = httpMock.expectOne(API_URL);
       expect(req.request.body).toEqual(newVehicle);
 
-      const vehicleResponse: VehicleInterface = {
-        ...newVehicle,
-        _id: '2'
-      };
-
+      const vehicleResponse: VehicleInterface = { ...newVehicle, _id: '2' };
       req.flush(vehicleResponse);
 
-      expect(service.vehicles()).toEqual([
-        ...vehicleList,
-        vehicleResponse
-      ]);
+      expect(service.vehicles()).toEqual([ferrariMock, vehicleResponse]);
       expect(service.vehicles().length).toBe(2);
     });
 
@@ -165,32 +155,13 @@ describe('VehicleService', () => {
 
   describe('updateVehicle', () => {
 
-    const vehicleList: VehicleInterface[] = [
-      {
-        _id: '1',
-        name: 'Lamborghini',
-        model: 'Huracan',
-        plate: 'L456',
-        location: {
-          lat: 42,
-          lng: 3
-        }
-      }
-    ];
-
     it('should call PUT /vehicles/:id with updated vehicle data', () => {
-      service.vehicles.set(vehicleList);
-      const oldVehicle = vehicleList[0];
+      loadMockVehicles([ferrariMock]);
 
-      const updatedVehicle: VehicleInterface = {
-        ...oldVehicle,
-        model: 'Huracan EVO',
-      };
+      const updatedVehicle: VehicleInterface = { ...ferrariMock, model: 'F8 Spider' };
+      service.updateVehicle(ferrariMock, updatedVehicle);
 
-      service.updateVehicle(oldVehicle, updatedVehicle);
-
-      const req = httpMock.expectOne('http://localhost:3000/vehicles/1');
-
+      const req = httpMock.expectOne(`${API_URL}/1`);
       expect(req.request.method).toBe('PUT');
       expect(req.request.body).toEqual(updatedVehicle);
 
@@ -198,69 +169,40 @@ describe('VehicleService', () => {
     });
 
     it('should replace updated vehicle in vehicles signal', () => {
-      service.vehicles.set(vehiclesMock);
+      loadMockVehicles();
 
-      const OldVehicle: VehicleInterface = vehiclesMock[0];
+      const newVehicle: VehicleInterface = { ...ferrariMock, plate: '111X' };
+      service.updateVehicle(ferrariMock, newVehicle);
 
-      const newVehicle: VehicleInterface = {
-        ...OldVehicle,
-        plate: '111X'
-      };
-
-      service.updateVehicle(OldVehicle, newVehicle);
-
-      const req = httpMock.expectOne('http://localhost:3000/vehicles/1');
-
-      expect(req.request.method).toBe('PUT');
-      expect(req.request.body).toEqual(newVehicle);
-
+      const req = httpMock.expectOne(`${API_URL}/1`);
       req.flush(newVehicle);
 
-      expect(service.vehicles()).toEqual([
-        newVehicle,
-        vehiclesMock[1],
-      ]);
+      expect(service.vehicles()).toEqual([newVehicle, paganiMock]);
     });
 
   });
 
   describe('updateVehicleLocation', () => {
 
-    const vehicle: VehicleInterface = {
-      _id: '1',
-      name: 'Ferrari',
-      model: 'F8 Tributo',
-      plate: 'F123',
-      location: {
-        lat: 41,
-        lng: 2
-      }
-    };
-
     it('should call PUT /vehicles/:id with location payload', () => {
+      loadMockVehicles([ferrariMock]);
+      service.updateVehicleLocation(ferrariMock, { lat: 42, lng: 3 });
 
-      service.vehicles.set([vehicle]);
-      service.updateVehicleLocation(vehicle, { lat: 42, lng: 3 });
-
-      const req = httpMock.expectOne('http://localhost:3000/vehicles/1');
+      const req = httpMock.expectOne(`${API_URL}/1`);
       expect(req.request.method).toBe('PUT');
       expect(req.request.body).toEqual({ location: { lat: 42, lng: 3 } });
 
-      req.flush({ ...vehicle, location: { lat: 42, lng: 3 } });
+      req.flush({ ...ferrariMock, location: { lat: 42, lng: 3 } });
 
       expect(service.vehicles()[0].location).toEqual({ lat: 42, lng: 3 });
     });
 
     it('should update only the location of the vehicle in vehicles signal', () => {
+      loadMockVehicles([ferrariMock]);
+      service.updateVehicleLocation(ferrariMock, { lat: 42, lng: 3 });
 
-      service.vehicles.set([vehicle]);
-      service.updateVehicleLocation(vehicle, { lat: 42, lng: 3 });
-
-      const req = httpMock.expectOne('http://localhost:3000/vehicles/1');
-      expect(req.request.method).toBe('PUT');
-      expect(req.request.body).toEqual({ location: { lat: 42, lng: 3 } });
-
-      req.flush({ ...vehicle, location: { lat: 42, lng: 3 } });
+      const req = httpMock.expectOne(`${API_URL}/1`);
+      req.flush({ ...ferrariMock, location: { lat: 42, lng: 3 } });
 
       expect(service.vehicles().length).toBe(1);
       expect(service.vehicles()[0]._id).toBe('1');
@@ -271,23 +213,11 @@ describe('VehicleService', () => {
 
   describe('deleteVehicle', () => {
 
-    const vehicle: VehicleInterface = {
-      _id: '1',
-      name: 'Ferrari',
-      model: 'F8 Tributo',
-      plate: 'F123',
-      location: {
-        lat: 41,
-        lng: 2
-      }
-    };
-
     it('should call DELETE /vehicles/:id endpoint', () => {
+      loadMockVehicles([ferrariMock]);
+      service.deleteVehicle(ferrariMock);
 
-      service.vehicles.set([vehicle]);
-      service.deleteVehicle(vehicle);
-
-      const req = httpMock.expectOne('http://localhost:3000/vehicles/1');
+      const req = httpMock.expectOne(`${API_URL}/1`);
       expect(req.request.method).toBe('DELETE');
       expect(req.request.body).toBeNull();
 
@@ -297,13 +227,10 @@ describe('VehicleService', () => {
     });
 
     it('should remove deleted vehicle from vehicles signal', () => {
-      service.vehicles.set(vehiclesMock);
-      service.deleteVehicle(vehiclesMock[0]);
+      loadMockVehicles();
+      service.deleteVehicle(ferrariMock);
 
-      const req = httpMock.expectOne('http://localhost:3000/vehicles/1');
-      expect(req.request.method).toBe('DELETE');
-      expect(req.request.body).toBeNull();
-
+      const req = httpMock.expectOne(`${API_URL}/1`);
       req.flush(null);
 
       expect(service.vehicles().length).toBe(1);
@@ -315,19 +242,11 @@ describe('VehicleService', () => {
 
   describe('addUserToVehicle', () => {
 
-    const vehicle: VehicleInterface = {
-      _id: '1',
-      name: 'Ferrari',
-      model: 'F8 Tributo',
-      plate: 'F123',
-      location: { lat: 41, lng: 2 }
-    };
-
     it('should call POST /vehicles/:id/users with email payload', () => {
-      service.vehicles.set([vehicle]);
+      loadMockVehicles([ferrariMock]);
       service.addUserToVehicle('1', 'test@test.com').subscribe();
 
-      const req = httpMock.expectOne('http://localhost:3000/vehicles/1/users');
+      const req = httpMock.expectOne(`${API_URL}/1/users`);
       expect(req.request.method).toBe('POST');
       expect(req.request.body).toEqual({ email: 'test@test.com' });
 
@@ -335,35 +254,35 @@ describe('VehicleService', () => {
     });
 
     it('should add new user to vehicle in vehicles signal', () => {
-      service.vehicles.set([vehicle]);
+      loadMockVehicles([ferrariMock]);
       service.addUserToVehicle('1', 'test@test.com').subscribe();
 
-      const req = httpMock.expectOne('http://localhost:3000/vehicles/1/users');
+      const req = httpMock.expectOne(`${API_URL}/1/users`);
       req.flush({ userId: 'user-1', email: 'test@test.com' });
 
       expect(service.vehicles()[0].users).toEqual([{ userId: 'user-1', email: 'test@test.com' }]);
     });
 
     it('should not modify other vehicles', () => {
-      service.vehicles.set(vehiclesMock);
+      loadMockVehicles();
       service.addUserToVehicle('1', 'test@test.com').subscribe();
 
-      const req = httpMock.expectOne('http://localhost:3000/vehicles/1/users');
+      const req = httpMock.expectOne(`${API_URL}/1/users`);
       req.flush({ userId: 'user-1', email: 'test@test.com' });
 
-      expect(service.vehicles()[1]).toEqual(vehiclesMock[1]);
+      expect(service.vehicles()[1]).toEqual(paganiMock);
     });
 
     it('should append to existing users array if present', () => {
       const vehicleWithUsers: VehicleInterface = {
-        ...vehicle,
+        ...ferrariMock,
         users: [{ userId: 'existing-user', email: 'existing@test.com' }]
       };
-      service.vehicles.set([vehicleWithUsers]);
+      loadMockVehicles([vehicleWithUsers]);
 
       service.addUserToVehicle('1', 'new@test.com').subscribe();
 
-      const req = httpMock.expectOne('http://localhost:3000/vehicles/1/users');
+      const req = httpMock.expectOne(`${API_URL}/1/users`);
       req.flush({ userId: 'new-user', email: 'new@test.com' });
 
       expect(service.vehicles()[0].users).toEqual([
@@ -373,10 +292,10 @@ describe('VehicleService', () => {
     });
 
     it('should initialize users array if not present', () => {
-      service.vehicles.set([vehicle]);
+      loadMockVehicles([ferrariMock]);
       service.addUserToVehicle('1', 'test@test.com').subscribe();
 
-      const req = httpMock.expectOne('http://localhost:3000/vehicles/1/users');
+      const req = httpMock.expectOne(`${API_URL}/1/users`);
       req.flush({ userId: 'user-1', email: 'test@test.com' });
 
       expect(Array.isArray(service.vehicles()[0].users)).toBeTrue();
@@ -388,11 +307,7 @@ describe('VehicleService', () => {
   describe('removeUserFromVehicle', () => {
 
     const vehicleWithUsers: VehicleInterface = {
-      _id: '1',
-      name: 'Ferrari',
-      model: 'F8 Tributo',
-      plate: 'F123',
-      location: { lat: 41, lng: 2 },
+      ...ferrariMock,
       users: [
         { userId: 'JordiTheBest', email: 'jordi@test.com' },
         { userId: 'other-user', email: 'other@test.com' }
@@ -400,30 +315,30 @@ describe('VehicleService', () => {
     };
 
     it('should call DELETE /vehicles/:id/users/:userId', () => {
-      service.vehicles.set([vehicleWithUsers]);
+      loadMockVehicles([vehicleWithUsers]);
       service.removeUserFromVehicle('1', 'other-user').subscribe();
 
-      const req = httpMock.expectOne('http://localhost:3000/vehicles/1/users/other-user');
+      const req = httpMock.expectOne(`${API_URL}/1/users/other-user`);
       expect(req.request.method).toBe('DELETE');
 
       req.flush(null);
     });
 
     it('should remove vehicle from signal when removed user is current user', () => {
-      service.vehicles.set([vehicleWithUsers]);
+      loadMockVehicles([vehicleWithUsers]);
       service.removeUserFromVehicle('1', 'JordiTheBest').subscribe();
 
-      const req = httpMock.expectOne('http://localhost:3000/vehicles/1/users/JordiTheBest');
+      const req = httpMock.expectOne(`${API_URL}/1/users/JordiTheBest`);
       req.flush(null);
 
       expect(service.vehicles()).toEqual([]);
     });
 
     it('should remove only the user from vehicle when removed user is not current user', () => {
-      service.vehicles.set([vehicleWithUsers]);
+      loadMockVehicles([vehicleWithUsers]);
       service.removeUserFromVehicle('1', 'other-user').subscribe();
 
-      const req = httpMock.expectOne('http://localhost:3000/vehicles/1/users/other-user');
+      const req = httpMock.expectOne(`${API_URL}/1/users/other-user`);
       req.flush(null);
 
       expect(service.vehicles().length).toBe(1);
@@ -433,21 +348,13 @@ describe('VehicleService', () => {
     });
 
     it('should not modify other vehicles', () => {
-      const secondVehicle: VehicleInterface = {
-        _id: '2',
-        name: 'Pagani',
-        model: 'Huayra',
-        plate: 'P456',
-        location: { lat: 42, lng: 3 }
-      };
-
-      service.vehicles.set([vehicleWithUsers, secondVehicle]);
+      loadMockVehicles([vehicleWithUsers, paganiMock]);
       service.removeUserFromVehicle('1', 'other-user').subscribe();
 
-      const req = httpMock.expectOne('http://localhost:3000/vehicles/1/users/other-user');
+      const req = httpMock.expectOne(`${API_URL}/1/users/other-user`);
       req.flush(null);
 
-      expect(service.vehicles()[1]).toEqual(secondVehicle);
+      expect(service.vehicles()[1]).toEqual(paganiMock);
     });
 
   });

--- a/src/app/features/vehicle/data-access/vehicle-service.spec.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.spec.ts
@@ -300,4 +300,30 @@ describe('VehicleService', () => {
     });
   });
 
+  describe('addUserToVehicle', () => {
+
+    it('should call POST /vehicles/:id/users with email payload');
+
+    it('should add new user to vehicle in vehicles signal');
+
+    it('should not modify other vehicles');
+
+    it('should append to existing users array if present');
+
+    it('should initialize users array if not present');
+
+  });
+
+  describe('removeUserFromVehicle', () => {
+
+    it('should call DELETE /vehicles/:id/users/:userId');
+
+    it('should remove vehicle from signal when removed user is current user');
+
+    it('should remove only the user from vehicle when removed user is not current user');
+
+    it('should not modify other vehicles');
+
+  });
+
 });

--- a/src/app/features/vehicle/data-access/vehicle-service.spec.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.spec.ts
@@ -387,13 +387,68 @@ describe('VehicleService', () => {
 
   describe('removeUserFromVehicle', () => {
 
-    it('should call DELETE /vehicles/:id/users/:userId');
+    const vehicleWithUsers: VehicleInterface = {
+      _id: '1',
+      name: 'Ferrari',
+      model: 'F8 Tributo',
+      plate: 'F123',
+      location: { lat: 41, lng: 2 },
+      users: [
+        { userId: 'JordiTheBest', email: 'jordi@test.com' },
+        { userId: 'other-user', email: 'other@test.com' }
+      ]
+    };
 
-    it('should remove vehicle from signal when removed user is current user');
+    it('should call DELETE /vehicles/:id/users/:userId', () => {
+      service.vehicles.set([vehicleWithUsers]);
+      service.removeUserFromVehicle('1', 'other-user').subscribe();
 
-    it('should remove only the user from vehicle when removed user is not current user');
+      const req = httpMock.expectOne('http://localhost:3000/vehicles/1/users/other-user');
+      expect(req.request.method).toBe('DELETE');
 
-    it('should not modify other vehicles');
+      req.flush(null);
+    });
+
+    it('should remove vehicle from signal when removed user is current user', () => {
+      service.vehicles.set([vehicleWithUsers]);
+      service.removeUserFromVehicle('1', 'JordiTheBest').subscribe();
+
+      const req = httpMock.expectOne('http://localhost:3000/vehicles/1/users/JordiTheBest');
+      req.flush(null);
+
+      expect(service.vehicles()).toEqual([]);
+    });
+
+    it('should remove only the user from vehicle when removed user is not current user', () => {
+      service.vehicles.set([vehicleWithUsers]);
+      service.removeUserFromVehicle('1', 'other-user').subscribe();
+
+      const req = httpMock.expectOne('http://localhost:3000/vehicles/1/users/other-user');
+      req.flush(null);
+
+      expect(service.vehicles().length).toBe(1);
+      expect(service.vehicles()[0].users).toEqual([
+        { userId: 'JordiTheBest', email: 'jordi@test.com' }
+      ]);
+    });
+
+    it('should not modify other vehicles', () => {
+      const secondVehicle: VehicleInterface = {
+        _id: '2',
+        name: 'Pagani',
+        model: 'Huayra',
+        plate: 'P456',
+        location: { lat: 42, lng: 3 }
+      };
+
+      service.vehicles.set([vehicleWithUsers, secondVehicle]);
+      service.removeUserFromVehicle('1', 'other-user').subscribe();
+
+      const req = httpMock.expectOne('http://localhost:3000/vehicles/1/users/other-user');
+      req.flush(null);
+
+      expect(service.vehicles()[1]).toEqual(secondVehicle);
+    });
 
   });
 

--- a/src/app/features/vehicle/data-access/vehicle-service.spec.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.spec.ts
@@ -39,12 +39,15 @@ describe('VehicleService', () => {
   });
 
   describe('Service creation', () => {
+
     it('should be created', () => {
       expect(service).toBeTruthy();
     });
+
   });
 
   describe('Initial state', () => {
+
     it('should initialize vehicles signal as empty array', () => {
       expect(service.vehicles()).toEqual([]);
     });
@@ -84,9 +87,11 @@ describe('VehicleService', () => {
 
       expect(service.vehicles()).toEqual(vehiclesMock);
     });
+
   });
 
   describe('addVehicles', () => {
+
     it('should call POST /vehicles endpoint with vehicle payload', () => {
       const vehicle: VehicleInterface = {
         _id: '1',
@@ -110,6 +115,7 @@ describe('VehicleService', () => {
     });
 
     it('should append created vehicle returned by backend to vehicles signal', () => {
+
       const vehicleList: VehicleInterface[] = [
         {
           _id: '1',
@@ -154,9 +160,11 @@ describe('VehicleService', () => {
       ]);
       expect(service.vehicles().length).toBe(2);
     });
+
   });
 
   describe('updateVehicle', () => {
+
     const vehicleList: VehicleInterface[] = [
       {
         _id: '1',
@@ -213,9 +221,11 @@ describe('VehicleService', () => {
         vehiclesMock[1],
       ]);
     });
+
   });
 
   describe('updateVehicleLocation', () => {
+
     const vehicle: VehicleInterface = {
       _id: '1',
       name: 'Ferrari',
@@ -256,9 +266,11 @@ describe('VehicleService', () => {
       expect(service.vehicles()[0]._id).toBe('1');
       expect(service.vehicles()[0].name).toBe('Ferrari');
     });
+
   });
 
   describe('deleteVehicle', () => {
+
     const vehicle: VehicleInterface = {
       _id: '1',
       name: 'Ferrari',
@@ -298,6 +310,7 @@ describe('VehicleService', () => {
       expect(service.vehicles()[0]._id).toBe('2');
       expect(service.vehicles()[0].name).toBe('Pagani');
     });
+
   });
 
   describe('addUserToVehicle', () => {

--- a/src/app/features/vehicle/data-access/vehicle-service.spec.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.spec.ts
@@ -315,15 +315,73 @@ describe('VehicleService', () => {
 
   describe('addUserToVehicle', () => {
 
-    it('should call POST /vehicles/:id/users with email payload');
+    const vehicle: VehicleInterface = {
+      _id: '1',
+      name: 'Ferrari',
+      model: 'F8 Tributo',
+      plate: 'F123',
+      location: { lat: 41, lng: 2 }
+    };
 
-    it('should add new user to vehicle in vehicles signal');
+    it('should call POST /vehicles/:id/users with email payload', () => {
+      service.vehicles.set([vehicle]);
+      service.addUserToVehicle('1', 'test@test.com').subscribe();
 
-    it('should not modify other vehicles');
+      const req = httpMock.expectOne('http://localhost:3000/vehicles/1/users');
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({ email: 'test@test.com' });
 
-    it('should append to existing users array if present');
+      req.flush({ userId: 'user-1', email: 'test@test.com' });
+    });
 
-    it('should initialize users array if not present');
+    it('should add new user to vehicle in vehicles signal', () => {
+      service.vehicles.set([vehicle]);
+      service.addUserToVehicle('1', 'test@test.com').subscribe();
+
+      const req = httpMock.expectOne('http://localhost:3000/vehicles/1/users');
+      req.flush({ userId: 'user-1', email: 'test@test.com' });
+
+      expect(service.vehicles()[0].users).toEqual([{ userId: 'user-1', email: 'test@test.com' }]);
+    });
+
+    it('should not modify other vehicles', () => {
+      service.vehicles.set(vehiclesMock);
+      service.addUserToVehicle('1', 'test@test.com').subscribe();
+
+      const req = httpMock.expectOne('http://localhost:3000/vehicles/1/users');
+      req.flush({ userId: 'user-1', email: 'test@test.com' });
+
+      expect(service.vehicles()[1]).toEqual(vehiclesMock[1]);
+    });
+
+    it('should append to existing users array if present', () => {
+      const vehicleWithUsers: VehicleInterface = {
+        ...vehicle,
+        users: [{ userId: 'existing-user', email: 'existing@test.com' }]
+      };
+      service.vehicles.set([vehicleWithUsers]);
+
+      service.addUserToVehicle('1', 'new@test.com').subscribe();
+
+      const req = httpMock.expectOne('http://localhost:3000/vehicles/1/users');
+      req.flush({ userId: 'new-user', email: 'new@test.com' });
+
+      expect(service.vehicles()[0].users).toEqual([
+        { userId: 'existing-user', email: 'existing@test.com' },
+        { userId: 'new-user', email: 'new@test.com' }
+      ]);
+    });
+
+    it('should initialize users array if not present', () => {
+      service.vehicles.set([vehicle]);
+      service.addUserToVehicle('1', 'test@test.com').subscribe();
+
+      const req = httpMock.expectOne('http://localhost:3000/vehicles/1/users');
+      req.flush({ userId: 'user-1', email: 'test@test.com' });
+
+      expect(Array.isArray(service.vehicles()[0].users)).toBeTrue();
+      expect(service.vehicles()[0].users?.length).toBe(1);
+    });
 
   });
 


### PR DESCRIPTION
### [PR Here](https://github.com/JordiMiravet/FleetManager-Frontend/pull/127)

### Description
Add the missing test coverage for `VehicleService`, specifically for `addUserToVehicle` and `removeUserFromVehicle`, which were not tested before. Also extracted shared mocks to reduce duplication across the suite.

---

### Acceptance Criteria
- [x] All tests pass consistently.
- [x] `addUserToVehicle` is tested covering payload, signal updates, existing/missing users array, and other vehicles unaffected.
- [x] `removeUserFromVehicle` is tested covering current user removal, other user removal, and other vehicles unaffected.
- [x] Extracted `API_URL`, `ferrariMock`, `paganiMock` and `loadMockVehicles()` helper to avoid repeated inline definitions across the file.

---

### Notes
- No production code changes.
- Shared mocks make the suite easier to maintain and keep test data consistent across describes.