### PR TITLE
test(create-button): fix broken selectors and remove duplicate tests (#142)

### DIFF
--- a/src/app/shared/ui/buttons/create-button/create-button.spec.ts
+++ b/src/app/shared/ui/buttons/create-button/create-button.spec.ts
@@ -31,25 +31,25 @@ describe('CreateButtonComponent', () => {
     });
 
     it('should render text when input is provided', () => {
-      (component.createText as any) = () => 'Add vehicle';
+      fixture.componentRef.setInput('createText', 'Add vehicle');
       fixture.detectChanges();
 
-      const span = fixture.nativeElement.querySelector('.create-button__text');
+      const button = fixture.nativeElement.querySelector('button');
 
-      expect(span.textContent.trim()).toBe('Add vehicle');
+      expect(button.textContent.trim()).toBe('Add vehicle');
     });
 
     it('should render empty text when input is null', () => {
-      (component.createText as any) = () => null;
+      fixture.componentRef.setInput('createText', null);
       fixture.detectChanges();
 
-      const span = fixture.nativeElement.querySelector('.create-button__text');
+      const button = fixture.nativeElement.querySelector('button');
 
-      expect(span.textContent.trim()).toBe('');
+      expect(button.textContent.trim()).toBe('');
     });
 
     it('should set aria-label from input', () => {
-      (component.createText as any) = () => 'Add vehicle';
+      fixture.componentRef.setInput('createText', 'Add vehicle');
       fixture.detectChanges();
 
       const button = fixture.nativeElement.querySelector('button');

--- a/src/app/shared/ui/buttons/create-button/create-button.spec.ts
+++ b/src/app/shared/ui/buttons/create-button/create-button.spec.ts
@@ -57,15 +57,6 @@ describe('CreateButtonComponent', () => {
       expect(button.getAttribute('aria-label')).toBe('Add vehicle');
     });
 
-    it('should call onClick when button is clicked', () => {
-      spyOn(component, 'onClick');
-
-      const button = fixture.nativeElement.querySelector('button');
-      button.click();
-
-      expect(component.onClick).toHaveBeenCalled();
-    });
-
   });
 
   describe('Output: create', () => {
@@ -85,18 +76,6 @@ describe('CreateButtonComponent', () => {
       button.click();
 
       expect(component.create.emit).toHaveBeenCalled();
-    });
-
-  });
-
-  describe('onClick method', () => {
-
-    it('should trigger create.emit()', () => {
-      const emitSpy = spyOn(component.create, 'emit');
-
-      component.onClick();
-
-      expect(emitSpy).toHaveBeenCalled();
     });
 
   });


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/pull/142)

## Summary
Fix and clean up the existing test suite for `CreateButtonComponent`. Some tests were checking for an element that no longer exists after a previous refactor, and others were duplicating the same coverage.

---

 ## What's included 
- [x] All tests pass consistently.
- [x] Fixed tests that were querying a `.create-button__text` element no longer present in the template, since the text is now rendered directly inside the button.
- [x] Replaced manual signal reassignment hack with `fixture.componentRef.setInput()`.
- [x] Removed duplicate tests covering the same `create` output emission.

---

## Notes
- No production code changes.
- The component itself was already correct; only the tests needed to catch up with a previous template refactor.