### PR TITLE
test(delete-button): remove duplicate tests and add missing icon class coverage (#144)

### DIFF
--- a/src/app/shared/ui/buttons/delete-button/delete-button.spec.ts
+++ b/src/app/shared/ui/buttons/delete-button/delete-button.spec.ts
@@ -37,8 +37,11 @@ describe('DeleteButtonComponent', () => {
       expect(icon.classList).toContain('pi-trash');
     });
 
-    it('should render trash icon with correct class');
+    it('should render trash icon with correct class', () => {
+      const icon = fixture.nativeElement.querySelector('i');
 
+      expect(icon.classList).toContain('delete-button__icon');
+    });
   });
 
   describe('Output: delete', () => {

--- a/src/app/shared/ui/buttons/delete-button/delete-button.spec.ts
+++ b/src/app/shared/ui/buttons/delete-button/delete-button.spec.ts
@@ -37,6 +37,8 @@ describe('DeleteButtonComponent', () => {
       expect(icon.classList).toContain('pi-trash');
     });
 
+    it('should render trash icon with correct class');
+
   });
 
   describe('Output: delete', () => {

--- a/src/app/shared/ui/buttons/delete-button/delete-button.spec.ts
+++ b/src/app/shared/ui/buttons/delete-button/delete-button.spec.ts
@@ -37,15 +37,6 @@ describe('DeleteButtonComponent', () => {
       expect(icon.classList).toContain('pi-trash');
     });
 
-    it('should call onClick when button is clicked', () => {
-      const spy = spyOn(component, 'onClick');
-
-      const button = fixture.nativeElement.querySelector('button');
-      button.click();
-
-      expect(spy).toHaveBeenCalled();
-    });
-
   });
 
   describe('Output: delete', () => {
@@ -63,18 +54,6 @@ describe('DeleteButtonComponent', () => {
 
       const button = fixture.nativeElement.querySelector('button');
       button.click();
-
-      expect(emitSpy).toHaveBeenCalled();
-    });
-
-  });
-
-  describe('onClick method', () => {
-
-    it('should trigger delete.emit()', () => {
-      const emitSpy = spyOn(component.delete, 'emit');
-
-      component.onClick();
 
       expect(emitSpy).toHaveBeenCalled();
     });


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/pull/144)

## Summary 
Clean up and complete the test suite for `DeleteButtonComponent`. Some tests were duplicating the same coverage, and a minor check on the icon class was missing.

---

## What's included 
- [x] All tests pass consistently.
- [x] Removed duplicate tests covering the same `delete` output emission.
- [x] Removed redundant `onClick` describe block that repeated existing coverage.
- [x] Added missing test for the trash icon CSS class.

---

## Notes
- No production code changes.
- Simple component with straightforward coverage — kept tests lean and without duplication.