### PR TITLE
test(edit-button): clean up duplicates and consolidate template tests (#145)

### DIFF
--- a/src/app/shared/ui/buttons/edit-button/edit-button.spec.ts
+++ b/src/app/shared/ui/buttons/edit-button/edit-button.spec.ts
@@ -8,8 +8,7 @@ describe('EditButtonComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [EditButtonComponent]
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(EditButtonComponent);
     component = fixture.componentInstance;
@@ -22,84 +21,42 @@ describe('EditButtonComponent', () => {
 
   describe('Template rendering', () => {
 
-    it('should render a button element', () => {
+    it('should render button with correct attributes', () => {
       const button = fixture.nativeElement.querySelector('button');
+
       expect(button).toBeTruthy();
-    });
-
-    it('should have type="button"', () => {
-      const button = fixture.nativeElement.querySelector('button');
       expect(button.getAttribute('type')).toBe('button');
+      expect(button.classList.contains('edit-button')).toBeTrue();
+      expect(button.getAttribute('aria-label')).toBe('Edit vehicle');
     });
 
-    it('should have the "edit-button" css class', () => {
-      const button = fixture.nativeElement.querySelector('button');
-      expect(button.getAttribute('class')).toContain('edit-button');
-    });
+    it('should render edit icon with correct classes', () => {
+      const icon = fixture.nativeElement.querySelector('i');
 
-    it('should have aria-label for accessibility', () => {
-      const button = fixture.nativeElement.querySelector('button');
-      expect(button.getAttribute('aria-label')).toBe('Edit vehicle'); 
-    });
-
-    it('should render the edit icon', () => {
-      const italic = fixture.nativeElement.querySelector('i');
-
-      expect(italic.getAttribute('class')).toContain('pi');
-      expect(italic.getAttribute('class')).toContain('pi-pen-to-square')
-    });
-
-    it('should call onClick when button is clicked', () => {
-      const spyButton = spyOn(component, 'onClick');
-      const button = fixture.nativeElement.querySelector('button');
-      button.click();
-
-      fixture.detectChanges();
-
-      expect(spyButton).toHaveBeenCalled();
+      expect(icon.classList).toContain('pi');
+      expect(icon.classList).toContain('pi-pen-to-square');
+      expect(icon.classList).toContain('edit-button__icon');
     });
 
   });
 
   describe('Output: edit', () => {
 
-    it('should have an edit output', () => {
-      expect(component.edit).toBeTruthy()
-    });
+    it('should emit edit when onClick is called', () => {
+      const emitSpy = spyOn(component.edit, 'emit');
 
-    it('should emit edit event when onClick is called', () => {
-      const spyEdit = spyOn(component.edit, 'emit');
       component.onClick();
 
-      expect(spyEdit).toHaveBeenCalled();
+      expect(emitSpy).toHaveBeenCalled();
     });
 
-    it('should emit edit event when button is clicked', () => {
-      spyOn(component.edit, 'emit'); 
+    it('should emit edit when button is clicked', () => {
+      const emitSpy = spyOn(component.edit, 'emit');
 
       const button = fixture.nativeElement.querySelector('button');
       button.click();
 
-      fixture.detectChanges();
-
-      expect(component.edit.emit).toHaveBeenCalled();
-    });
-
-    it('should expose an edit output', () => {
-      expect(component.edit).toBeTruthy();
-    });
-
-  });
-
-  describe('onClick method', () => {
-
-    it('should call edit.emit()', () => {
-      spyOn(component.edit, 'emit');
-
-      component.onClick()
-      fixture.detectChanges();
-
-      expect(component.edit.emit).toHaveBeenCalled()
+      expect(emitSpy).toHaveBeenCalled();
     });
 
   });


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/pull/145)

## Summary  
Clean up the test suite for `EditButtonComponent`. Tests were fragmented across too many small `it` blocks, several were duplicating the same check, and a minor assertion on the icon class was missing.

---

## What's included 
- [x] All tests pass consistently.
- [x] Consolidated fragmented button attribute tests into a single readable block.
- [x] Removed duplicate tests for output emission and onClick coverage.
- [x] Removed redundant `onClick` describe block.
- [x] Added missing assertion for the `edit-button__icon` class on the icon element.

---

## Notes
- No production code changes.
- Kept the same coverage with fewer, cleaner tests.