### PR TITLE
test(user-button): add full test suite (#146)

### DIFF
--- a/src/app/shared/ui/buttons/user-button/user-button.spec.ts
+++ b/src/app/shared/ui/buttons/user-button/user-button.spec.ts
@@ -20,4 +20,21 @@ describe('UserButtonComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('Template rendering', () => {
+
+    it('should render button with correct attributes');
+
+    it('should render user icon with correct classes');
+
+  });
+
+  describe('Output: user', () => {
+
+    it('should emit user when onClick is called');
+
+    it('should emit user when button is clicked');
+
+  });
+
 });

--- a/src/app/shared/ui/buttons/user-button/user-button.spec.ts
+++ b/src/app/shared/ui/buttons/user-button/user-button.spec.ts
@@ -44,9 +44,22 @@ describe('UserButtonComponent', () => {
 
   describe('Output: user', () => {
 
-    it('should emit user when onClick is called');
+    it('should emit user when onClick is called', () => {
+      const emitSpy = spyOn(component.user, 'emit');
 
-    it('should emit user when button is clicked');
+      component.onClick();
+
+      expect(emitSpy).toHaveBeenCalled();
+    });
+
+    it('should emit user when button is clicked', () => {
+      const emitSpy = spyOn(component.user, 'emit');
+
+      const button = fixture.nativeElement.querySelector('button');
+      button.click();
+
+      expect(emitSpy).toHaveBeenCalled();
+    });
 
   });
 

--- a/src/app/shared/ui/buttons/user-button/user-button.spec.ts
+++ b/src/app/shared/ui/buttons/user-button/user-button.spec.ts
@@ -23,9 +23,22 @@ describe('UserButtonComponent', () => {
 
   describe('Template rendering', () => {
 
-    it('should render button with correct attributes');
+    it('should render button with correct attributes', () => {
+      const button = fixture.nativeElement.querySelector('button');
 
-    it('should render user icon with correct classes');
+      expect(button).toBeTruthy();
+      expect(button.getAttribute('type')).toBe('button');
+      expect(button.classList.contains('user-button')).toBeTrue();
+    });
+
+    it('should render user icon with correct classes', () => {
+      const icon = fixture.nativeElement.querySelector('i');
+
+      expect(icon.classList).toContain('fa-solid');
+      expect(icon.classList).toContain('fa-user-group');
+      expect(icon.classList).toContain('user-button__icon');
+      expect(icon.getAttribute('aria-hidden')).toBe('true');
+    });
 
   });
 


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/pull/146)

## Summary 
Add the missing test suite for `UserButtonComponent`, a shared button used to open the user management modal from the vehicle table.

---

 ## What's included 
- [x] All tests pass consistently.
- [x] Button renders correctly with the right type and class.
- [x] User group icon renders with the correct classes and aria-hidden attribute.
- [x] Clicking the button emits the `user` output.

---

## Notes
- No production code changes.
- Simple component — kept tests lean and consistent with the other shared button components.