### PR TITLE
test(dark-mode-toggle): merge double beforeEach and add full test suite (#143)

### DIFF
--- a/src/app/shared/ui/buttons/dark-mode-toggle/dark-mode-toggle.spec.ts
+++ b/src/app/shared/ui/buttons/dark-mode-toggle/dark-mode-toggle.spec.ts
@@ -9,11 +9,10 @@ describe('DarkModeToggleComponent', () => {
 
   beforeEach(async () => {
     mockThemeService = jasmine.createSpyObj('ThemeService', ['toggle', 'isDark']);
+    mockThemeService.isDark.and.returnValue(false);
 
     await TestBed.configureTestingModule({
-      imports: [ 
-        DarkModeToggleComponent
-      ],
+      imports: [DarkModeToggleComponent],
       providers: [
         { provide: ThemeService, useValue: mockThemeService }
       ]
@@ -21,10 +20,7 @@ describe('DarkModeToggleComponent', () => {
 
     fixture = TestBed.createComponent(DarkModeToggleComponent);
     component = fixture.componentInstance;
-  });
 
-  beforeEach(() => {
-    mockThemeService.isDark.and.returnValue(false);
     fixture.detectChanges();
   });
 


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/pull/143)

## Summary
Add the full test suite for `DarkModeToggleComponent` and clean up a redundant `beforeEach` block that was splitting setup logic unnecessarily.

---

## What's included
- Merged double `beforeEach` into a single clean setup block with explicit default state.
- Template renders correctly in both light and dark states.
- Active class is applied correctly depending on theme state.
- Sun and moon icons switch based on the current theme.
- Aria attributes update dynamically with the theme state.
- Clicking the toggle calls the theme service correctly.

---

## Notes
- No production code changes.
- `ThemeService` is mocked via `jasmine.createSpyObj` to isolate the component behaviour.