### PR TITLE
test(vehicle-modal-service): fix misleading test name, extract shared mocks and improve readability (#128)

### DIFF
--- a/src/app/features/vehicle/state/vehicle-modal-service.spec.ts
+++ b/src/app/features/vehicle/state/vehicle-modal-service.spec.ts
@@ -47,12 +47,15 @@ describe('VehicleModalService', () => {
   });
 
   describe('service creation', () => {
+
     it('should be created', () => {
       expect(service).toBeTruthy();
     });
+
   });
 
   describe('initial state', () => {
+
     it('should initialize activeModal as Closed', () => {
       expect(service.activeModal()).toBe(VehicleModalState.Closed);
     });
@@ -64,9 +67,11 @@ describe('VehicleModalService', () => {
     it('should initialize selectedVehicle as null', () => {
       expect(service.selectedVehicle()).toBe(null);
     });
+
   });
 
   describe('openCreate behavior', () => {
+
     it('should open modal in create mode', () => {
       service.openCreate();
 
@@ -85,9 +90,11 @@ describe('VehicleModalService', () => {
       expect(service.selectedVehicle()).toBe(null);
       expect(service.activeModal()).toBe(VehicleModalState.VehicleForm);
     });
+
   });
 
   describe('openEdit behavior', () => {
+
     it('should open modal in edit mode with selected vehicle', () => {
       service.openEdit(mockVehicle);
 
@@ -111,6 +118,7 @@ describe('VehicleModalService', () => {
   });
 
   describe('openConfirmDelete behavior', () => {
+
     it('should open confirm delete modal with selected vehicle', () => {
       service.openConfirmDelete(mockVehicle);
 
@@ -124,9 +132,11 @@ describe('VehicleModalService', () => {
 
       expect(service.formMode()).toBe('edit');
     });
+
   });
 
   describe('close behavior', () => {
+
     it('should close the modal', () => {
       service.openCreate();
       service.close();
@@ -151,6 +161,7 @@ describe('VehicleModalService', () => {
   });
 
   describe('state transitions', () => {
+
     it('should allow reopening modal after closing', () => {
       service.openCreate();
       service.close();
@@ -171,5 +182,7 @@ describe('VehicleModalService', () => {
       expect(service.selectedVehicle()).toBe(mockVehicle);
       expect(service.activeModal()).toBe(VehicleModalState.VehicleForm);
     });
+
   });
+  
 });

--- a/src/app/features/vehicle/state/vehicle-modal-service.spec.ts
+++ b/src/app/features/vehicle/state/vehicle-modal-service.spec.ts
@@ -26,6 +26,16 @@ describe('VehicleModalService', () => {
     }
   };
 
+  const mockVehicle2: VehicleInterface = {
+    name: 'Pagani',
+    model: 'Huayra',
+    plate: '5669JKX',
+    location: {
+      lat: 42.48644688584013,
+      lng: 3.3107555554463137
+    }
+  };
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
@@ -87,16 +97,6 @@ describe('VehicleModalService', () => {
     });
 
     it('should replace selected vehicle when openEdit is called again', () => {
-      const mockVehicle2: VehicleInterface = {
-        name: 'Pagani',
-        model: 'Huayra',
-        plate: '5669JKX',
-        location: {
-          lat: 42.48644688584013,
-          lng: 3.3107555554463137
-        }
-      };
-
       service.openEdit(mockVehicle);
       expect(service.selectedVehicle()).toBe(mockVehicle);
       expect(service.formMode()).toBe('edit');
@@ -107,6 +107,7 @@ describe('VehicleModalService', () => {
       expect(service.formMode()).toBe('edit');
       expect(service.activeModal()).toBe(VehicleModalState.VehicleForm);
     });
+
   });
 
   describe('openConfirmDelete behavior', () => {

--- a/src/app/features/vehicle/state/vehicle-modal-service.spec.ts
+++ b/src/app/features/vehicle/state/vehicle-modal-service.spec.ts
@@ -140,12 +140,13 @@ describe('VehicleModalService', () => {
       expect(service.selectedVehicle()).toBe(null);
     });
 
-    it('should not modify formMode when closing modal', () => {
+    it('should reset formMode to create when closing modal', () => {
       service.openEdit(mockVehicle);
       service.close();
 
       expect(service.formMode()).toBe('create');
     });
+
   });
 
   describe('state transitions', () => {


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/pull/128)

## Summary
Fix a misleading test name, extract a shared vehicle mock and add some spacing to improve readability in `VehicleModalService` tests.

---

## What's included
- Fixed misleading test name: `'should not modify formMode when closing modal'` -> `'should reset formMode to create when closing modal'`.
- Extracted `mockVehicle2` as a shared constant alongside `mockVehicle`.
- Added blank lines between describes for better readability.
- Initial state, all modal transitions and close behavior are fully covered.

---

## Notes
- No production code changes.
- Service has no HTTP dependencies — no mocking needed beyond `Auth`.