### PR TITLE
test(header): replace RouterTestingModule, merge duplicate tests and add class assertion (#158)

### DIFF
--- a/src/app/core/layout/header/header.spec.ts
+++ b/src/app/core/layout/header/header.spec.ts
@@ -1,10 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HeaderComponent } from '../header/header';
-import { RouterTestingModule } from '@angular/router/testing';
 import { signal } from '@angular/core';
+import { provideRouter } from '@angular/router';
 
 import { AuthService } from '../../../features/auth/data-access/auth-service';
-import { provideRouter } from '@angular/router';
 
 class MockAuthService {
   isLogged = signal(false);
@@ -41,11 +40,12 @@ describe('HeaderComponent', () => {
 
   describe('Template rendering', () => {
 
-    it('should render the header element with correct role', () => {
+    it('should render the header element with correct role and class', () => {
       const header = fixture.nativeElement.querySelector('header');
-      
+
       expect(header).toBeTruthy();
       expect(header.getAttribute('role')).toBe('banner');
+      expect(header.classList.contains('header')).toBeTrue();
     });
 
     it('should render NavigationComponent', () => {
@@ -56,14 +56,6 @@ describe('HeaderComponent', () => {
     it('should render AuthActionsComponent', () => {
       const authActions = fixture.nativeElement.querySelector('app-auth-actions');
       expect(authActions).toBeTruthy();
-    });
-
-    it('should render the header element with correct role', () => {
-      const header = fixture.nativeElement.querySelector('header');
-
-      expect(header).toBeTruthy();
-      expect(header.getAttribute('role')).toBe('banner');
-      expect(header.classList.contains('header')).toBeTrue();
     });
 
   });

--- a/src/app/core/layout/header/header.spec.ts
+++ b/src/app/core/layout/header/header.spec.ts
@@ -4,6 +4,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { signal } from '@angular/core';
 
 import { AuthService } from '../../../features/auth/data-access/auth-service';
+import { provideRouter } from '@angular/router';
 
 class MockAuthService {
   isLogged = signal(false);
@@ -17,12 +18,11 @@ describe('HeaderComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         HeaderComponent,
-        RouterTestingModule
       ],
-      providers: [{
-        provide: AuthService,
-        useClass: MockAuthService
-      }]
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useClass: MockAuthService},
+      ]
     })
     .compileComponents();
 

--- a/src/app/core/layout/header/header.spec.ts
+++ b/src/app/core/layout/header/header.spec.ts
@@ -58,6 +58,14 @@ describe('HeaderComponent', () => {
       expect(authActions).toBeTruthy();
     });
 
+    it('should render the header element with correct role', () => {
+      const header = fixture.nativeElement.querySelector('header');
+
+      expect(header).toBeTruthy();
+      expect(header.getAttribute('role')).toBe('banner');
+      expect(header.classList.contains('header')).toBeTrue();
+    });
+
   });
 
   describe('Layout structure', () => {


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/pull/158)

## Summary
Fix the test suite for `HeaderComponent` by replacing the deprecated `RouterTestingModule`, merging a duplicated test and adding a missing assertion on the header CSS class.

---

## What's included
- Replaced deprecated `RouterTestingModule` with `provideRouter([])`.
- Removed unused `RouterTestingModule` import.
- Merged two duplicate `should render the header element with correct role` tests into one.
- Added assertion for the `header` CSS class.

---

## Notes
- No production code changes.
- Simple wrapper component — kept tests lean and focused on structure and role.