### PR TITLE
test(account-drawer): add component test coverage (#159)

### DIFF
--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -1,14 +1,21 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { AccountDrawerComponent } from './account-drawer';
+import { ThemeService } from '../../services/theme/theme-service';
 
 describe('AccountDrawerComponent', () => {
   let component: AccountDrawerComponent;
   let fixture: ComponentFixture<AccountDrawerComponent>;
 
+  const mockThemeService = jasmine.createSpyObj('ThemeService', ['toggle', 'isDark']);
+
   beforeEach(async () => {
+    mockThemeService.isDark.and.returnValue(false);
+
     await TestBed.configureTestingModule({
-      imports: [AccountDrawerComponent]
+      imports: [AccountDrawerComponent],
+      providers: [
+        { provide: ThemeService, useValue: mockThemeService }
+      ]
     })
     .compileComponents();
 
@@ -20,4 +27,59 @@ describe('AccountDrawerComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('Template rendering', () => {
+
+    it('should render the backdrop');
+
+    it('should render the aside with role dialog');
+
+    it('should render the drawer title');
+
+    it('should render the close button');
+
+    it('should render all menu items');
+
+    it('should render the dark mode toggle');
+
+    it('should render the logout button');
+
+  });
+
+  describe('Output: close', () => {
+
+    it('should emit close when onClose is called');
+
+    it('should emit close when backdrop is clicked');
+
+    it('should emit close when close button is clicked');
+
+  });
+
+  describe('Output: logout', () => {
+
+    it('should emit logout when onLogout is called');
+
+    it('should emit logout when logout button is clicked');
+
+  });
+
+  describe('onLogout method', () => {
+
+    it('should emit both logout and close when onLogout is called');
+
+  });
+
+  describe('Accessibility', () => {
+
+    it('should have aria-hidden on backdrop');
+
+    it('should have aria-label on the aside');
+
+    it('should have aria-label on the close button');
+
+    it('should have aria-hidden on icons');
+
+  });
+
 });

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -142,13 +142,33 @@ describe('AccountDrawerComponent', () => {
 
   describe('Accessibility', () => {
 
-    it('should have aria-hidden on backdrop');
+    it('should have aria-hidden on backdrop', () => {
+      const backdrop = fixture.nativeElement.querySelector('.drawer__backdrop');
 
-    it('should have aria-label on the aside');
+      expect(backdrop.getAttribute('aria-hidden')).toBe('true');
+    });
 
-    it('should have aria-label on the close button');
+    it('should have aria-label on the aside', () => {
+      const aside = fixture.nativeElement.querySelector('aside.drawer');
 
-    it('should have aria-hidden on icons');
+      expect(aside.getAttribute('aria-label')).toBe(component.drawerMsg.aria.drawer);
+    });
+
+    it('should have aria-label on the close button', () => {
+      const button = fixture.nativeElement.querySelector('.drawer__close');
+
+      expect(button.getAttribute('aria-label')).toBe(component.drawerMsg.aria.closeButton);
+    });
+
+    it('should have aria-hidden on icons', () => {
+      const hiddenIcons = fixture.nativeElement.querySelectorAll('i[aria-hidden="true"]');
+
+      expect(hiddenIcons.length).toBeGreaterThan(0);
+
+      hiddenIcons.forEach((icon: HTMLElement) => {
+        expect(icon.getAttribute('aria-hidden')).toBe('true')
+      });
+    });
 
   });
 

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -110,9 +110,20 @@ describe('AccountDrawerComponent', () => {
 
   describe('Output: logout', () => {
 
-    it('should emit logout when onLogout is called');
+    it('should emit logout when onLogout is called', () => {
+      spyOn(component.logout, 'emit');
+      component.onLogout();
 
-    it('should emit logout when logout button is clicked');
+      expect(component.logout.emit).toHaveBeenCalled();
+    });
+
+    it('should emit logout when logout button is clicked', () => {
+      spyOn(component.logout, 'emit');
+      const logoutButton = fixture.nativeElement.querySelector('.drawer__item--danger');
+      logoutButton.click();
+
+      expect(component.logout.emit).toHaveBeenCalled();
+    });
 
   });
 

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -129,7 +129,14 @@ describe('AccountDrawerComponent', () => {
 
   describe('onLogout method', () => {
 
-    it('should emit both logout and close when onLogout is called');
+    it('should emit both logout and close when onLogout is called', () => {
+      spyOn(component.logout, 'emit');
+      spyOn(component.close, 'emit');
+      component.onLogout();
+
+      expect(component.logout.emit).toHaveBeenCalledTimes(1);
+      expect(component.close.emit).toHaveBeenCalledTimes(1);
+    });
 
   });
 

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -30,19 +30,54 @@ describe('AccountDrawerComponent', () => {
 
   describe('Template rendering', () => {
 
-    it('should render the backdrop');
+    it('should render the backdrop', () => {
+      const backdrop = fixture.nativeElement.querySelector('.drawer__backdrop');
 
-    it('should render the aside with role dialog');
+      expect(backdrop).toBeTruthy();
+    });
 
-    it('should render the drawer title');
+    it('should render the aside with role dialog', () => {
+      const aside = fixture.nativeElement.querySelector('aside.drawer');
 
-    it('should render the close button');
+      expect(aside).toBeTruthy();
+      expect(aside.getAttribute('role')).toBe('dialog');
+    });
 
-    it('should render all menu items');
+    it('should render the drawer title', () => {
+      const title = fixture.nativeElement.querySelector('.drawer__title');
 
-    it('should render the dark mode toggle');
+      expect(title).toBeTruthy();
+      expect(title.textContent.trim()).toBe(component.drawerMsg.title);
+    });
 
-    it('should render the logout button');
+    it('should render the close button', () => {
+      const button = fixture.nativeElement.querySelector('.drawer__close');
+
+      expect(button).toBeTruthy();
+    });
+
+    it('should render all menu items', () => {
+      const items = fixture.nativeElement.querySelectorAll('.drawer__section:first-of-type .drawer__item');
+
+      expect(items.length).toBe(4);
+      expect(items[0].textContent).toContain(component.drawerMsg.items.editProfile);
+      expect(items[1].textContent).toContain(component.drawerMsg.items.settings);
+      expect(items[2].textContent).toContain(component.drawerMsg.items.language);
+      expect(items[3].textContent).toContain(component.drawerMsg.items.darkMode);
+    });
+
+    it('should render the dark mode toggle', () => {
+      const toggle = fixture.nativeElement.querySelector('app-dark-mode-toggle');
+
+      expect(toggle).toBeTruthy();
+    });
+
+    it('should render the logout button', () => {
+      const button = fixture.nativeElement.querySelector('.drawer__item--danger');
+
+      expect(button).toBeTruthy();
+      expect(button.textContent).toContain(component.drawerMsg.buttons.logout);
+    });
 
   });
 

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -83,11 +83,28 @@ describe('AccountDrawerComponent', () => {
 
   describe('Output: close', () => {
 
-    it('should emit close when onClose is called');
+    it('should emit close when onClose is called', () => {
+      spyOn(component.close, 'emit');
+      component.onClose();
 
-    it('should emit close when backdrop is clicked');
+      expect(component.close.emit).toHaveBeenCalled();
+    });
 
-    it('should emit close when close button is clicked');
+    it('should emit close when backdrop is clicked', () => {
+      spyOn(component.close, 'emit');
+      const backdrop = fixture.nativeElement.querySelector('.drawer__backdrop');
+      backdrop.click();
+
+      expect(component.close.emit).toHaveBeenCalled();
+    });
+
+    it('should emit close when close button is clicked', () => {
+      spyOn(component.close, 'emit');
+      const button = fixture.nativeElement.querySelector('.drawer__close');
+      button.click();
+
+      expect(component.close.emit).toHaveBeenCalled();
+    });
 
   });
 

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+
 import { AccountDrawerComponent } from './account-drawer';
 import { ThemeService } from '../../services/theme/theme-service';
 
@@ -16,8 +17,7 @@ describe('AccountDrawerComponent', () => {
       providers: [
         { provide: ThemeService, useValue: mockThemeService }
       ]
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(AccountDrawerComponent);
     component = fixture.componentInstance;


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/159)

## Summary
Add a complete test suite for `AccountDrawerComponent`, covering template rendering, output events, component behavior, and accessibility requirements.

---

## What's included
- Added template rendering tests for:
  - Backdrop.
  - Drawer container with `role="dialog"`.
  - Drawer title.
  - Close button.
  - Menu items.
  - Dark mode toggle.
  - Logout button.
- Added output event tests for:
  - `close` emission through `onClose()`.
  - `close` emission when clicking the backdrop.
  - `close` emission when clicking the close button.
  - `logout` emission through `onLogout()`.
  - `logout` emission when clicking the logout button.
- Added behavior test to verify that `onLogout()` emits both `logout` and `close`.
- Added accessibility tests covering:
  - `aria-hidden` on the backdrop.
  - `aria-label` on the drawer container.
  - `aria-label` on the close button.
  - `aria-hidden` on decorative icons.
- Reused localized messages from `component.drawerMsg` instead of hardcoded strings to make assertions less brittle.

---

## Notes
- No production code changes.
- Test coverage was added only for existing component behavior and accessibility attributes.