### PR TITLE
test(auth-actions): improve and stabilize unit test suite (#161)

### DIFF
--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -220,7 +220,16 @@ describe('AuthActionsComponent', () => {
 
   describe('Drawer integration', () => {
 
-    it('should close drawer when close event is emitted from account drawer');
+    it('should close drawer when close event is emitted from account drawer', () => {
+      component.isLogged = signal(true);
+      component.isDrawerOpen.set(true);
+      fixture.detectChanges();
+
+      const drawer = fixture.debugElement.query(sel => sel.name === 'app-account-drawer');
+      drawer.triggerEventHandler('close');
+
+      expect(component.isDrawerOpen()).toBeFalse();
+    });
 
   });
 

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -58,6 +58,14 @@ describe('AuthActionsComponent', () => {
 
   });
 
+  describe('Initial state', () => {
+
+    it('should initialize isDrawerOpen as false');
+
+    it('should reflect isLogged signal from AuthService');
+
+  });
+
   describe('Template rendering', () => {
 
     it('should render settings button when user is logged', () => {
@@ -151,6 +159,18 @@ describe('AuthActionsComponent', () => {
 
   });
 
+  describe('Method: openDrawer', () => {
+
+    it('should set isDrawerOpen to true');
+
+  });
+
+  describe('Method: closeDrawer', () => {
+
+    it('should set isDrawerOpen to false');
+
+  });
+
   describe('Interactions', () => {
 
     it('should call logout and navigate when onLogout is called', async () => {
@@ -179,6 +199,34 @@ describe('AuthActionsComponent', () => {
 
       expect(component.onLogout).toHaveBeenCalled();
     });
+
+  });
+
+  describe('Drawer integration', () => {
+
+    it('should close drawer when close event is emitted from account drawer');
+
+  });
+
+  describe('Error handling', () => {
+
+    it('should log error when logout fails');
+
+  });
+
+  describe('Reactive updates', () => {
+
+    it('should update template when isLogged signal changes');
+
+  });
+
+  describe('Accessibility', () => {
+
+    it('should have aria-label on settings button');
+
+    it('should have aria-label on login button');
+
+    it('should have aria-label on register button');
 
   });
 

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -31,16 +31,14 @@ describe('AuthActionsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        AuthActionsComponent,
-      ],
+      imports: [AuthActionsComponent],
       providers: [
-        { provide: AuthService, useClass: MockAuthService },
-        LayoutMessagesService,
         provideRouter([
           { path: 'login', component: LoginComponent },
           { path: 'register', component: RegisterComponent }
-        ])
+        ]),
+        { provide: AuthService, useClass: MockAuthService },
+        LayoutMessagesService,
       ]
     }).compileComponents();
 

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -167,7 +167,12 @@ describe('AuthActionsComponent', () => {
 
   describe('Method: openDrawer', () => {
 
-    it('should set isDrawerOpen to true');
+    it('should set isDrawerOpen to true', () => {
+      component.isDrawerOpen.set(false);
+      component.openDrawer();
+
+      expect(component.isDrawerOpen()).toBeTrue();
+    });
 
   });
 

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -60,9 +60,15 @@ describe('AuthActionsComponent', () => {
 
   describe('Initial state', () => {
 
-    it('should initialize isDrawerOpen as false');
+    it('should initialize isDrawerOpen as false', () => {
+      expect(component.isDrawerOpen()).toBeFalse();
+    });
 
-    it('should reflect isLogged signal from AuthService');
+    it('should reflect isLogged signal from AuthService', () => {
+      const authService = TestBed.inject(AuthService) as unknown as MockAuthService;
+
+      expect(component.isLogged()).toBe(authService.isLogged());
+    });
 
   });
 

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -253,7 +253,23 @@ describe('AuthActionsComponent', () => {
 
   describe('Reactive updates', () => {
 
-    it('should update template when isLogged signal changes');
+    it('should update template when isLogged signal changes', () => {
+      component.isLogged = signal(false);
+      fixture.detectChanges();
+
+      let loginButton = fixture.nativeElement.querySelector('[data-test="loginButton"]');
+      let registerButton = fixture.nativeElement.querySelector('[data-test="registerButton"]');
+
+      expect(loginButton).toBeTruthy();
+      expect(registerButton).toBeTruthy();
+
+      component.isLogged = signal(true);
+      fixture.detectChanges();
+
+      const settingsButton = fixture.nativeElement.querySelector('.navbar__auth-button');
+
+      expect(settingsButton).toBeTruthy();
+    });
 
   });
 

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingHarness, RouterTestingModule } from '@angular/router/testing';
+import { RouterTestingHarness } from '@angular/router/testing';
 import { Component, signal } from '@angular/core';
 import { provideRouter, Router } from '@angular/router';
 
@@ -33,7 +33,6 @@ describe('AuthActionsComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         AuthActionsComponent,
-        RouterTestingModule
       ],
       providers: [
         { provide: AuthService, useClass: MockAuthService },

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -178,7 +178,12 @@ describe('AuthActionsComponent', () => {
 
   describe('Method: closeDrawer', () => {
 
-    it('should set isDrawerOpen to false');
+    it('should set isDrawerOpen to false', () => {
+      component.isDrawerOpen.set(true);
+      component.closeDrawer();
+
+      expect(component.isDrawerOpen()).toBeFalse();
+    });
 
   });
 

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -275,11 +275,32 @@ describe('AuthActionsComponent', () => {
 
   describe('Accessibility', () => {
 
-    it('should have aria-label on settings button');
+    it('should have aria-label on settings button', () => {
+      component.isLogged = signal(true);
+      fixture.detectChanges();
 
-    it('should have aria-label on login button');
+      const button = fixture.nativeElement.querySelector('.navbar__auth-button');
 
-    it('should have aria-label on register button');
+      expect(button.getAttribute('aria-label')).toBe(component.drawerMsg.aria.openButton);
+    });
+
+    it('should have aria-label on login button', () => {
+      component.isLogged = signal(false);
+      fixture.detectChanges();
+
+      const button = fixture.nativeElement.querySelector('[data-test="loginButton"]');
+
+      expect(button.getAttribute('aria-label')).toBe(component.authActionsMsg.aria.login);
+    });
+
+    it('should have aria-label on register button', () => {
+      component.isLogged = signal(false);
+      fixture.detectChanges();
+
+      const button = fixture.nativeElement.querySelector('[data-test="registerButton"]');
+
+      expect(button.getAttribute('aria-label')).toBe(component.authActionsMsg.aria.register);
+    });
 
   });
 

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { RouterTestingHarness } from '@angular/router/testing';
 import { Component, signal } from '@angular/core';
 import { provideRouter, Router } from '@angular/router';
@@ -235,7 +235,19 @@ describe('AuthActionsComponent', () => {
 
   describe('Error handling', () => {
 
-    it('should log error when logout fails');
+    it('should log error when logout fails', fakeAsync(() => {
+      const consoleSpy = spyOn(console, 'error');
+      const authService = TestBed.inject(AuthService) as unknown as MockAuthService;
+
+      authService.logout.and.returnValue(
+        Promise.reject(new Error('Logout error'))
+      );
+
+      component.onLogout();
+      tick();
+
+      expect(consoleSpy).toHaveBeenCalledWith(jasmine.any(Error));
+    }));
 
   });
 


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/pull/161)

## Summary
Improve and stabilize the `AuthActionsComponent` unit tests by fixing unstable tests, improving async handling, and adding missing coverage for component behavior and accessibility.

---

## What's included
- Reorganised and stabilised existing test suite structure.
- Fixed async handling in logout error flow tests.
- Added missing tests for:
  - `openDrawer` method
  - `closeDrawer` method
  - Initial component state
  - Reactive updates when `isLogged` signal changes
  - Accessibility attributes on auth buttons
- Improved integration between `AuthActionsComponent` and `AccountDrawerComponent`.
- Standardised testing approach using signals and Angular TestBed best practices.

---

## Notes
- No production code changes.
- Focused on test stability, readability, and maintainability.