### PR TITLE
test(vehicle-selector): improve template rendering coverage (#123)

### DIFF
--- a/src/app/features/vehicle/components/vehicle-selector/vehicle-selector.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-selector/vehicle-selector.spec.ts
@@ -10,12 +10,12 @@ describe('VehicleSelectorComponent', () => {
 
   const mockVehicles: VehicleInterface[] = [
     { name: 'Ferrari', model: 'F8 Tributo', plate: 'F123', location: { lat: 41, lng: 2 } },
-    { name: 'Pagani', model: 'Huayra', plate: 'P456', location: { lat: 42, lng: 3 } }
+    { name: 'Pagani', model: 'Huayra', plate: 'P456', location: { lat: 42, lng: 3 } },
   ];
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [VehicleSelectorComponent]
+      imports: [ VehicleSelectorComponent ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(VehicleSelectorComponent);
@@ -24,12 +24,15 @@ describe('VehicleSelectorComponent', () => {
   });
 
   describe('component creation', () => {
+
     it('should create', () => {
       expect(component).toBeTruthy();
     });
+
   });
 
   describe('inputs', () => {
+
     it('should accept vehicles input', () => {
       const mockSignal = () => mockVehicles;
       (component.vehicles as any) = mockSignal;
@@ -43,9 +46,11 @@ describe('VehicleSelectorComponent', () => {
 
       expect(component.selectedPlate()).toBe('F123');
     });
+
   });
 
   describe('template rendering', () => {
+
     it('should render the select element', () => {
       const select = fixture.nativeElement.querySelector('#vehicle-select');
       expect(select).toBeTruthy();
@@ -108,9 +113,11 @@ describe('VehicleSelectorComponent', () => {
 
       expect(select.value).toBe('');
     });
+
   });
 
   describe('events', () => {
+
     it('should emit vehicleSelected when a vehicle is selected', () => {
       (component.vehicles as any) = () => mockVehicles;
       fixture.detectChanges();
@@ -162,6 +169,7 @@ describe('VehicleSelectorComponent', () => {
 
       expect(component.vehicleSelected.emit).not.toHaveBeenCalled();
     });
+
   });
 
 });

--- a/src/app/features/vehicle/components/vehicle-selector/vehicle-selector.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-selector/vehicle-selector.spec.ts
@@ -149,7 +149,18 @@ describe('VehicleSelectorComponent', () => {
     });
 
     it('should not emit when selecting an unknown plate from DOM', () => {
+      (component.vehicles as any) = () => mockVehicles;
+      fixture.detectChanges();
 
+      spyOn(component.vehicleSelected, 'emit');
+
+      const select: HTMLSelectElement =
+        fixture.nativeElement.querySelector('#vehicle-select');
+
+      select.value = 'UNKNOWN';
+      select.dispatchEvent(new Event('change'));
+
+      expect(component.vehicleSelected.emit).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/features/vehicle/components/vehicle-selector/vehicle-selector.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-selector/vehicle-selector.spec.ts
@@ -71,6 +71,22 @@ describe('VehicleSelectorComponent', () => {
       const select: HTMLSelectElement = fixture.nativeElement.querySelector('select');
       expect(select.value).toBe('F123');
     });
+
+    it('should render only the default option when there are no vehicles', () => {
+
+    });
+
+    it('should render vehicle names', () => {
+
+    });
+
+    it('should render the accessibility label', () => {
+
+    });
+
+    it('should not select any vehicle when selectedPlate is null', () => {
+
+    });
   });
 
   describe('events', () => {
@@ -109,6 +125,10 @@ describe('VehicleSelectorComponent', () => {
       } as any);
 
       expect(component.vehicleSelected.emit).not.toHaveBeenCalled();
+    });
+
+    it('should not emit when selecting an unknown plate from DOM', () => {
+
     });
   });
 

--- a/src/app/features/vehicle/components/vehicle-selector/vehicle-selector.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-selector/vehicle-selector.spec.ts
@@ -73,19 +73,40 @@ describe('VehicleSelectorComponent', () => {
     });
 
     it('should render only the default option when there are no vehicles', () => {
+      (component.vehicles as any) = () => [];
+      fixture.detectChanges();
 
+      const options = fixture.nativeElement.querySelectorAll('option');
+
+      expect(options.length).toBe(1);
     });
 
     it('should render vehicle names', () => {
+      (component.vehicles as any) = () => mockVehicles;
+      fixture.detectChanges();
 
+      const options = fixture.nativeElement.querySelectorAll('option');
+
+      expect(options[1].textContent.trim()).toBe('Ferrari');
+      expect(options[2].textContent.trim()).toBe('Pagani');
     });
 
     it('should render the accessibility label', () => {
+      const label = fixture.nativeElement.querySelector('label');
 
+      expect(label).toBeTruthy();
+      expect(label.getAttribute('for')).toBe('vehicle-select');
     });
 
     it('should not select any vehicle when selectedPlate is null', () => {
+      (component.vehicles as any) = signal(mockVehicles);
+      (component.selectedPlate as any) = signal(null);
 
+      fixture.detectChanges();
+
+      const select: HTMLSelectElement = fixture.nativeElement.querySelector('select');
+
+      expect(select.value).toBe('');
     });
   });
 


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/pull/123)

## Summary

Improve template coverage for `VehicleSelectorComponent` by adding tests for empty states, rendered content and accessibility-related markup.

---

## What's included

* Added test to verify that only the default option is rendered when no vehicles are available.
* Added test to verify that vehicle names are correctly rendered in the select options.
* Added test to verify the accessibility label and its association with the select element.
* Added test to verify behavior when `selectedPlate` is `null`.
* Existing component creation, input handling and event emission tests remain unchanged.

---

## Notes

* No production code changes.
* Tests focus exclusively on template rendering and DOM behavior.
* Coverage has been extended without modifying component implementation.