### PR TITLE
test(vehicle-form-modal): fix signal hacks, add missing coverage and extract shared mock (#126)

### DIFF
--- a/src/app/features/vehicle/modals/vehicle-form-modal/vehicle-form-modal.spec.ts
+++ b/src/app/features/vehicle/modals/vehicle-form-modal/vehicle-form-modal.spec.ts
@@ -167,6 +167,36 @@ describe('VehicleFormModalComponent', () => {
 
   });
 
+  describe('accessibility', () => {
+
+    it('should have role dialog on the backdrop', () => {
+      const dialog = fixture.nativeElement.querySelector('dialog');
+      expect(dialog.getAttribute('role')).toBe('dialog');
+    });
+
+    it('should have aria-modal on the backdrop', () => {
+      const dialog = fixture.nativeElement.querySelector('dialog');
+      expect(dialog.getAttribute('aria-modal')).toBe('true');
+    });
+
+    it('should have aria-labelledby pointing to the legend', () => {
+      const dialog = fixture.nativeElement.querySelector('dialog');
+      const legend = fixture.nativeElement.querySelector('#modal-title');
+
+      expect(dialog.getAttribute('aria-labelledby')).toBe(legend.getAttribute('id'));
+    });
+
+    it('should set aria-invalid on touched invalid fields', () => {
+      component.form.get('name')?.setValue('');
+      component.form.get('name')?.markAsTouched();
+      fixture.detectChanges();
+
+      const input = fixture.nativeElement.querySelector('#createVehicleName');
+      expect(input.getAttribute('aria-invalid')).toBe('true');
+    });
+
+  });
+
   describe('template interaction', () => {
 
     it('should call onSubmit on Enter key press', () => {
@@ -239,36 +269,6 @@ describe('VehicleFormModalComponent', () => {
 
       const button = fixture.nativeElement.querySelector('.modal__button--save');
       expect(button.textContent).toContain(component.formMsg.buttons.update);
-    });
-
-  });
-
-  describe('accessibility', () => {
-
-    it('should have role dialog on the backdrop', () => {
-      const dialog = fixture.nativeElement.querySelector('dialog');
-      expect(dialog.getAttribute('role')).toBe('dialog');
-    });
-
-    it('should have aria-modal on the backdrop', () => {
-      const dialog = fixture.nativeElement.querySelector('dialog');
-      expect(dialog.getAttribute('aria-modal')).toBe('true');
-    });
-
-    it('should have aria-labelledby pointing to the legend', () => {
-      const dialog = fixture.nativeElement.querySelector('dialog');
-      const legend = fixture.nativeElement.querySelector('#modal-title');
-
-      expect(dialog.getAttribute('aria-labelledby')).toBe(legend.getAttribute('id'));
-    });
-
-    it('should set aria-invalid on touched invalid fields', () => {
-      component.form.get('name')?.setValue('');
-      component.form.get('name')?.markAsTouched();
-      fixture.detectChanges();
-
-      const input = fixture.nativeElement.querySelector('#createVehicleName');
-      expect(input.getAttribute('aria-invalid')).toBe('true');
     });
 
   });

--- a/src/app/features/vehicle/modals/vehicle-form-modal/vehicle-form-modal.spec.ts
+++ b/src/app/features/vehicle/modals/vehicle-form-modal/vehicle-form-modal.spec.ts
@@ -210,19 +210,35 @@ describe('VehicleFormModalComponent', () => {
   describe('mode input', () => {
 
     it('should show create title when mode is create', () => {
+      fixture.componentRef.setInput('mode', 'create');
+      fixture.detectChanges();
 
+      const legend = fixture.nativeElement.querySelector('.modal__legend');
+      expect(legend.textContent).toContain(component.formMsg.title.create);
     });
 
     it('should show edit title when mode is edit', () => {
+      fixture.componentRef.setInput('mode', 'edit');
+      fixture.detectChanges();
 
+      const legend = fixture.nativeElement.querySelector('.modal__legend');
+      expect(legend.textContent).toContain(component.formMsg.title.edit);
     });
 
     it('should show create button label when mode is create', () => {
+      fixture.componentRef.setInput('mode', 'create');
+      fixture.detectChanges();
 
+      const button = fixture.nativeElement.querySelector('.modal__button--save');
+      expect(button.textContent).toContain(component.formMsg.buttons.create);
     });
 
     it('should show update button label when mode is edit', () => {
+      fixture.componentRef.setInput('mode', 'edit');
+      fixture.detectChanges();
 
+      const button = fixture.nativeElement.querySelector('.modal__button--save');
+      expect(button.textContent).toContain(component.formMsg.buttons.update);
     });
 
   });

--- a/src/app/features/vehicle/modals/vehicle-form-modal/vehicle-form-modal.spec.ts
+++ b/src/app/features/vehicle/modals/vehicle-form-modal/vehicle-form-modal.spec.ts
@@ -41,6 +41,7 @@ describe('VehicleFormModalComponent', () => {
       expect(formControl['name']).toBeTruthy();
       expect(formControl['model']).toBeTruthy();
       expect(formControl['plate']).toBeTruthy();
+      expect(formControl['imageUrl']).toBeTruthy();
     });
 
     it('should patch form values when mode is edit', () => {
@@ -50,10 +51,9 @@ describe('VehicleFormModalComponent', () => {
         plate: '123456',
       };
 
-      (component as any).vehicle = signal(inputVehicle);
-      (component as any).mode = signal('edit');
-
-      component.ngOnChanges();
+      fixture.componentRef.setInput('vehicle', inputVehicle);
+      fixture.componentRef.setInput('mode', 'edit');
+      fixture.detectChanges();
 
       expect(component.form.get('name')?.value).toBe(inputVehicle.name);
       expect(component.form.get('model')?.value).toBe(inputVehicle.model);
@@ -61,8 +61,8 @@ describe('VehicleFormModalComponent', () => {
     });
 
     it('should reset form when mode is create', () => {
-      (component as any).mode = signal('create');
-      component.ngOnChanges();
+      fixture.componentRef.setInput('mode', 'create');
+      fixture.detectChanges();
 
       expect(component.form.get('name')?.value).toBeNull();
       expect(component.form.get('model')?.value).toBeNull();

--- a/src/app/features/vehicle/modals/vehicle-form-modal/vehicle-form-modal.spec.ts
+++ b/src/app/features/vehicle/modals/vehicle-form-modal/vehicle-form-modal.spec.ts
@@ -104,10 +104,17 @@ describe('VehicleFormModalComponent', () => {
     });
 
     it('should return invalidUrl error when imageUrl has invalid format', () => {
-      component.form.get('imageUrl')?.setValue('not-a-valid-url!!!');
+      component.form.get('imageUrl')?.setValue('not a valid url!!!');
       component.form.get('imageUrl')?.markAsTouched();
 
       expect(component.getFieldError('imageUrl')).toBeTruthy();
+    });
+
+    it('should return null for imageUrl when value is empty', () => {
+      component.form.get('imageUrl')?.setValue('');
+      component.form.get('imageUrl')?.markAsTouched();
+
+      expect(component.getFieldError('imageUrl')).toBeNull();
     });
 
     it('should return null when field does not exist', () => {

--- a/src/app/features/vehicle/modals/vehicle-form-modal/vehicle-form-modal.spec.ts
+++ b/src/app/features/vehicle/modals/vehicle-form-modal/vehicle-form-modal.spec.ts
@@ -207,4 +207,44 @@ describe('VehicleFormModalComponent', () => {
 
   });
 
+  describe('mode input', () => {
+
+    it('should show create title when mode is create', () => {
+
+    });
+
+    it('should show edit title when mode is edit', () => {
+
+    });
+
+    it('should show create button label when mode is create', () => {
+
+    });
+
+    it('should show update button label when mode is edit', () => {
+
+    });
+
+  });
+
+  describe('accessibility', () => {
+
+    it('should have role dialog on the backdrop', () => {
+
+    });
+
+    it('should have aria-modal on the backdrop', () => {
+
+    });
+
+    it('should have aria-labelledby pointing to the legend', () => {
+
+    });
+
+    it('should set aria-invalid on touched invalid fields', () => {
+
+    });
+
+  });
+
 });

--- a/src/app/features/vehicle/modals/vehicle-form-modal/vehicle-form-modal.spec.ts
+++ b/src/app/features/vehicle/modals/vehicle-form-modal/vehicle-form-modal.spec.ts
@@ -246,19 +246,29 @@ describe('VehicleFormModalComponent', () => {
   describe('accessibility', () => {
 
     it('should have role dialog on the backdrop', () => {
-
+      const dialog = fixture.nativeElement.querySelector('dialog');
+      expect(dialog.getAttribute('role')).toBe('dialog');
     });
 
     it('should have aria-modal on the backdrop', () => {
-
+      const dialog = fixture.nativeElement.querySelector('dialog');
+      expect(dialog.getAttribute('aria-modal')).toBe('true');
     });
 
     it('should have aria-labelledby pointing to the legend', () => {
+      const dialog = fixture.nativeElement.querySelector('dialog');
+      const legend = fixture.nativeElement.querySelector('#modal-title');
 
+      expect(dialog.getAttribute('aria-labelledby')).toBe(legend.getAttribute('id'));
     });
 
     it('should set aria-invalid on touched invalid fields', () => {
+      component.form.get('name')?.setValue('');
+      component.form.get('name')?.markAsTouched();
+      fixture.detectChanges();
 
+      const input = fixture.nativeElement.querySelector('#createVehicleName');
+      expect(input.getAttribute('aria-invalid')).toBe('true');
     });
 
   });

--- a/src/app/features/vehicle/modals/vehicle-form-modal/vehicle-form-modal.spec.ts
+++ b/src/app/features/vehicle/modals/vehicle-form-modal/vehicle-form-modal.spec.ts
@@ -14,6 +14,12 @@ describe('VehicleFormModalComponent', () => {
       getIdToken: () => Promise.resolve('MyToken')
     }
   };
+  
+  const vehicleMock: VehicleInterface = {
+    name: 'R34',
+    model: 'Nissan Skyline GT-R R34',
+    plate: '123456',
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -44,19 +50,13 @@ describe('VehicleFormModalComponent', () => {
     });
 
     it('should patch form values when mode is edit', () => {
-      const inputVehicle: VehicleInterface = {
-        name: 'R34',
-        model: 'Nissan Skyline GT-R R34',
-        plate: '123456',
-      };
-
-      fixture.componentRef.setInput('vehicle', inputVehicle);
+      fixture.componentRef.setInput('vehicle', vehicleMock);
       fixture.componentRef.setInput('mode', 'edit');
       fixture.detectChanges();
 
-      expect(component.form.get('name')?.value).toBe(inputVehicle.name);
-      expect(component.form.get('model')?.value).toBe(inputVehicle.model);
-      expect(component.form.get('plate')?.value).toBe(inputVehicle.plate);
+      expect(component.form.get('name')?.value).toBe(vehicleMock.name);
+      expect(component.form.get('model')?.value).toBe(vehicleMock.model);
+      expect(component.form.get('plate')?.value).toBe(vehicleMock.plate);
     });
 
     it('should reset form when mode is create', () => {

--- a/src/app/features/vehicle/modals/vehicle-form-modal/vehicle-form-modal.spec.ts
+++ b/src/app/features/vehicle/modals/vehicle-form-modal/vehicle-form-modal.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { signal } from '@angular/core';
 import { Auth } from '@angular/fire/auth';
 
 import { VehicleFormModalComponent } from './vehicle-form-modal';


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/pull/126)

## Summary
Fix brittle test patterns in `VehicleFormModalComponent`, add missing coverage for mode input and accessibility, and clean up shared data.

---

## What's included
- Replaced `(component as any).vehicle = signal(...)` hacks with `fixture.componentRef.setInput()`.
- Added `imageUrl` control assertion in form initialization.
- Added empty string case for `imageUrl` validation.
- Added `mode input` describe covering title and button label switching between create and edit.
- Added `accessibility` describe covering role, aria-modal, aria-labelledby and aria-invalid.
- Extracted shared `vehicleMock` constant to avoid inline repetition.
- Removed unused `signal` import.
- Reordered describes for better readability.

---

## Notes
- No production code changes.
- `ngOnChanges` is now triggered naturally via `setInput` instead of being called directly.