### PR TITLE
test(vehicle-table-actions): add full test suite with shared helpers (#121)

### DIFF
--- a/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
@@ -20,4 +20,77 @@ describe('VehicleTableActionsComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('initial state', () => {
+
+    it('should initialize query as empty string');
+
+    it('should initialize sortField as "name"');
+
+    it('should initialize sortDir as "asc"');
+
+  });
+
+  describe('onQueryChange', () => {
+
+    it('should update query signal when input changes');
+
+    it('should emit filterChange with updated query');
+
+  });
+
+  describe('onSortFieldChange', () => {
+
+    it('should update sortField signal when select changes');
+
+    it('should emit filterChange with updated sortField');
+
+  });
+
+  describe('toggleSortDir', () => {
+
+    it('should toggle sortDir from asc to desc');
+
+    it('should toggle sortDir from desc to asc');
+
+    it('should emit filterChange after toggling');
+
+  });
+
+  describe('template rendering', () => {
+
+    it('should render search input');
+
+    it('should render sort direction button');
+
+    it('should render sort field select with options');
+
+    it('should show asc icon when sortDir is asc');
+
+    it('should show desc icon when sortDir is desc');
+
+  });
+
+  describe('template interactions', () => {
+
+    it('should call onQueryChange when typing in search input');
+
+    it('should call onSortFieldChange when selecting sort field');
+
+    it('should call toggleSortDir when clicking sort button');
+
+  });
+
+  describe('accessibility', () => {
+
+    it('should have aria-label on search input');
+
+    it('should have aria-label on sort direction button');
+
+    it('should have aria-label on sort field select');
+
+    it('should have aria-hidden on search icon');
+
+  });
+
 });

--- a/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
@@ -67,23 +67,16 @@ describe('VehicleTableActionsComponent', () => {
   describe('onSortFieldChange', () => {
 
     it('should update sortField signal when select changes', () => {
-      const event = { target: { value: 'model' } } as unknown as Event;
-      component.onSortFieldChange(event);
+      component.onSortFieldChange(createInputEvent('model'));
 
       expect(component.sortField()).toBe('model');
     });
 
     it('should emit filterChange with updated sortField', () => {
       const emitSpy = spyOn(component.filterChange, 'emit');
-      const event = { target: { value: 'plate' } } as unknown as Event;
+      component.onSortFieldChange(createInputEvent('plate'));
 
-      component.onSortFieldChange(event);
-
-      expect(emitSpy).toHaveBeenCalledWith({
-        query: '',
-        sortField: 'plate',
-        sortDir: 'asc'
-      });
+      expect(emitSpy).toHaveBeenCalledWith({ ...defaultFilterState, sortField: 'plate' });
     });
 
   });
@@ -105,14 +98,9 @@ describe('VehicleTableActionsComponent', () => {
 
     it('should emit filterChange after toggling', () => {
       const emitSpy = spyOn(component.filterChange, 'emit');
-
       component.toggleSortDir();
 
-      expect(emitSpy).toHaveBeenCalledWith({
-        query: '',
-        sortField: 'name',
-        sortDir: 'desc'
-      });
+      expect(emitSpy).toHaveBeenCalledWith({ ...defaultFilterState, sortDir: 'desc' });
     });
 
   });

--- a/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
@@ -39,9 +39,25 @@ describe('VehicleTableActionsComponent', () => {
 
   describe('onQueryChange', () => {
 
-    it('should update query signal when input changes');
+    it('should update query signal when input changes', () => {
+      const event = { target: { value: 'Ferrari' } } as unknown as Event;
+      component.onQueryChange(event);
 
-    it('should emit filterChange with updated query');
+      expect(component.query()).toBe('Ferrari');
+    });
+
+    it('should emit filterChange with updated query', () => {
+      const emitSpy = spyOn(component.filterChange, 'emit');
+      const event = { target: { value: 'Ferrari' } } as unknown as Event;
+
+      component.onQueryChange(event);
+
+      expect(emitSpy).toHaveBeenCalledWith({
+        query: 'Ferrari',
+        sortField: 'name',
+        sortDir: 'asc'
+      });
+    });
 
   });
 

--- a/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
@@ -185,13 +185,25 @@ describe('VehicleTableActionsComponent', () => {
 
   describe('accessibility', () => {
 
-    it('should have aria-label on search input');
+    it('should have aria-label on search input', () => {
+      const input = fixture.nativeElement.querySelector('.vehicle-actions__search-input');
+      expect(input.getAttribute('aria-label')).toBe(component.actionsMsg.aria.searchInput);
+    });
 
-    it('should have aria-label on sort direction button');
+    it('should have aria-label on sort direction button', () => {
+      const button = fixture.nativeElement.querySelector('.vehicle-actions__sort-button');
+      expect(button.getAttribute('aria-label')).toBe(component.actionsMsg.aria.sortDirButton);
+    });
 
-    it('should have aria-label on sort field select');
+    it('should have aria-label on sort field select', () => {
+      const select = fixture.nativeElement.querySelector('.vehicle-actions__sort-select');
+      expect(select.getAttribute('aria-label')).toBe(component.actionsMsg.aria.sortFieldSelect);
+    });
 
-    it('should have aria-hidden on search icon');
+    it('should have aria-hidden on search icon', () => {
+      const icon = fixture.nativeElement.querySelector('.vehicle-actions__search-icon');
+      expect(icon.getAttribute('aria-hidden')).toBe('true');
+    });
 
   });
 

--- a/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
@@ -154,11 +154,32 @@ describe('VehicleTableActionsComponent', () => {
 
   describe('template interactions', () => {
 
-    it('should call onQueryChange when typing in search input');
+    it('should call onQueryChange when typing in search input', () => {
+      const spy = spyOn(component, 'onQueryChange');
 
-    it('should call onSortFieldChange when selecting sort field');
+      const input: HTMLInputElement = fixture.nativeElement.querySelector('.vehicle-actions__search-input');
+      input.dispatchEvent(new Event('input'));
 
-    it('should call toggleSortDir when clicking sort button');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should call onSortFieldChange when selecting sort field', () => {
+      const spy = spyOn(component, 'onSortFieldChange');
+
+      const select: HTMLSelectElement = fixture.nativeElement.querySelector('.vehicle-actions__sort-select');
+      select.dispatchEvent(new Event('change'));
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should call toggleSortDir when clicking sort button', () => {
+      const spy = spyOn(component, 'toggleSortDir');
+
+      const button: HTMLButtonElement = fixture.nativeElement.querySelector('.vehicle-actions__sort-button');
+      button.click();
+
+      expect(spy).toHaveBeenCalled();
+    });
 
   });
 

--- a/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
@@ -23,11 +23,17 @@ describe('VehicleTableActionsComponent', () => {
 
   describe('initial state', () => {
 
-    it('should initialize query as empty string');
+    it('should initialize query as empty string', () => {
+      expect(component.query()).toBe('');
+    });
 
-    it('should initialize sortField as "name"');
+    it('should initialize sortField as "name"', () => {
+      expect(component.sortField()).toBe('name');
+    });
 
-    it('should initialize sortDir as "asc"');
+    it('should initialize sortDir as "asc"', () => {
+      expect(component.sortDir()).toBe('asc');
+    });
 
   });
 

--- a/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
@@ -63,9 +63,25 @@ describe('VehicleTableActionsComponent', () => {
 
   describe('onSortFieldChange', () => {
 
-    it('should update sortField signal when select changes');
+    it('should update sortField signal when select changes', () => {
+      const event = { target: { value: 'model' } } as unknown as Event;
+      component.onSortFieldChange(event);
 
-    it('should emit filterChange with updated sortField');
+      expect(component.sortField()).toBe('model');
+    });
+
+    it('should emit filterChange with updated sortField', () => {
+      const emitSpy = spyOn(component.filterChange, 'emit');
+      const event = { target: { value: 'plate' } } as unknown as Event;
+
+      component.onSortFieldChange(event);
+
+      expect(emitSpy).toHaveBeenCalledWith({
+        query: '',
+        sortField: 'plate',
+        sortDir: 'asc'
+      });
+    });
 
   });
 

--- a/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
@@ -116,15 +116,39 @@ describe('VehicleTableActionsComponent', () => {
 
   describe('template rendering', () => {
 
-    it('should render search input');
+    it('should render search input', () => {
+      const input = fixture.nativeElement.querySelector('.vehicle-actions__search-input');
+      expect(input).toBeTruthy();
+    });
 
-    it('should render sort direction button');
+    it('should render sort direction button', () => {
+      const button = fixture.nativeElement.querySelector('.vehicle-actions__sort-button');
+      expect(button).toBeTruthy();
+    });
 
-    it('should render sort field select with options');
+    it('should render sort field select with options', () => {
+      const select = fixture.nativeElement.querySelector('.vehicle-actions__sort-select');
+      const options = select.querySelectorAll('option');
 
-    it('should show asc icon when sortDir is asc');
+      expect(select).toBeTruthy();
+      expect(options.length).toBe(3);
+    });
 
-    it('should show desc icon when sortDir is desc');
+    it('should show asc icon when sortDir is asc', () => {
+      component.sortDir.set('asc');
+      fixture.detectChanges();
+
+      const icon = fixture.nativeElement.querySelector('.vehicle-actions__sort-button i');
+      expect(icon.classList).toContain('pi-sort-amount-down');
+    });
+
+    it('should show desc icon when sortDir is desc', () => {
+      component.sortDir.set('desc');
+      fixture.detectChanges();
+
+      const icon = fixture.nativeElement.querySelector('.vehicle-actions__sort-button i');
+      expect(icon.classList).toContain('pi-sort-amount-up');
+    });
 
   });
 

--- a/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
@@ -2,6 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { VehicleTableActionsComponent } from './vehicle-table-actions';
 
+function createInputEvent(value: string): Event {
+  return { target: { value } } as unknown as Event;
+}
+
+const defaultFilterState = {
+  query: '',
+  sortField: 'name' as const,
+  sortDir: 'asc' as const
+};
+
 describe('VehicleTableActionsComponent', () => {
   let component: VehicleTableActionsComponent;
   let fixture: ComponentFixture<VehicleTableActionsComponent>;
@@ -40,23 +50,16 @@ describe('VehicleTableActionsComponent', () => {
   describe('onQueryChange', () => {
 
     it('should update query signal when input changes', () => {
-      const event = { target: { value: 'Ferrari' } } as unknown as Event;
-      component.onQueryChange(event);
+      component.onQueryChange(createInputEvent('Ferrari'));
 
       expect(component.query()).toBe('Ferrari');
     });
 
     it('should emit filterChange with updated query', () => {
       const emitSpy = spyOn(component.filterChange, 'emit');
-      const event = { target: { value: 'Ferrari' } } as unknown as Event;
+      component.onQueryChange(createInputEvent('Ferrari'));
 
-      component.onQueryChange(event);
-
-      expect(emitSpy).toHaveBeenCalledWith({
-        query: 'Ferrari',
-        sortField: 'name',
-        sortDir: 'asc'
-      });
+      expect(emitSpy).toHaveBeenCalledWith({ ...defaultFilterState, query: 'Ferrari' });
     });
 
   });
@@ -205,6 +208,6 @@ describe('VehicleTableActionsComponent', () => {
       expect(icon.getAttribute('aria-hidden')).toBe('true');
     });
 
-  });
+  }); 
 
 });

--- a/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
@@ -87,11 +87,30 @@ describe('VehicleTableActionsComponent', () => {
 
   describe('toggleSortDir', () => {
 
-    it('should toggle sortDir from asc to desc');
+    it('should toggle sortDir from asc to desc', () => {
+      component.toggleSortDir();
 
-    it('should toggle sortDir from desc to asc');
+      expect(component.sortDir()).toBe('desc');
+    });
 
-    it('should emit filterChange after toggling');
+    it('should toggle sortDir from desc to asc', () => {
+      component.sortDir.set('desc');
+      component.toggleSortDir();
+
+      expect(component.sortDir()).toBe('asc');
+    });
+
+    it('should emit filterChange after toggling', () => {
+      const emitSpy = spyOn(component.filterChange, 'emit');
+
+      component.toggleSortDir();
+
+      expect(emitSpy).toHaveBeenCalledWith({
+        query: '',
+        sortField: 'name',
+        sortDir: 'desc'
+      });
+    });
 
   });
 


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/pull/121)

## Summary
Add the full test suite for `VehicleTableActionsComponent`, covering all signals, event handlers, template rendering, interactions and accessibility attributes.

---

## What's included
- Added `initial state` describe covering all three signal default values.
- Added `onQueryChange` describe covering signal update and filterChange emission.
- Added `onSortFieldChange` describe covering signal update and filterChange emission.
- Added `toggleSortDir` describe covering both toggle directions and filterChange emission.
- Added `template rendering` describe covering search input, sort button, select options and icon switching.
- Added `template interactions` describe covering native DOM event dispatching for all three controls.
- Added `accessibility` describe covering aria-label and aria-hidden attributes.
- Extracted `createInputEvent()` helper to avoid repeating the event mock pattern.
- Extracted `defaultFilterState` constant to avoid repeating the base filter object.

---

## Notes
- No production code changes.