### PR TITLE
test(vehicle-table-pagination): add initial test suite for current implementation (#120)

### DIFF
--- a/src/app/features/vehicle/components/vehicle-table-pagination/vehicle-table-pagination.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-pagination/vehicle-table-pagination.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { HttpClientModule } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 import { Auth} from '@angular/fire/auth';
 
 import { VehicleTablePaginationComponent } from './vehicle-table-pagination';
@@ -17,12 +17,10 @@ describe('VehicleTablePaginationComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        VehicleTablePaginationComponent,
-        HttpClientModule,
-      ],
+      imports: [VehicleTablePaginationComponent],
       providers: [
         { provide: Auth, useValue: authMock },
+        provideRouter([]),
       ]
     })
     .compileComponents();

--- a/src/app/features/vehicle/components/vehicle-table-pagination/vehicle-table-pagination.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-pagination/vehicle-table-pagination.spec.ts
@@ -85,13 +85,31 @@ describe('VehicleTablePaginationComponent', () => {
 
   describe('accessibility', () => {
 
-    it('should have aria-label on previous page button');
+    it('should have aria-label on previous page button', () => {
+      const button = fixture.nativeElement.querySelector('.vehicle-pagination__button:first-of-type');
+      expect(button.getAttribute('aria-label')).toBe(component.paginationMsg.aria.previousPage);
+    });
 
-    it('should have aria-label on next page button');
+    it('should have aria-label on next page button', () => {
+      const buttons = fixture.nativeElement.querySelectorAll('.vehicle-pagination__button');
+      expect(buttons[1].getAttribute('aria-label')).toBe(component.paginationMsg.aria.nextPage);
+    });
 
-    it('should have aria-live on vehicle count spans');
+    it('should have aria-live on vehicle count spans', () => {
+      const values = fixture.nativeElement.querySelectorAll('.vehicle-pagination__value');
 
-    it('should have aria-hidden on pagination icons');
+      values.forEach((value: HTMLElement) => {
+        expect(value.getAttribute('aria-live')).toBe('polite');
+      });
+    });
+
+    it('should have aria-hidden on pagination icons', () => {
+      const icons = fixture.nativeElement.querySelectorAll('.vehicle-pagination__button i');
+      
+      icons.forEach((icon: HTMLElement) => {
+        expect(icon.getAttribute('aria-hidden')).toBe('true');
+      });
+    });
 
   });
 

--- a/src/app/features/vehicle/components/vehicle-table-pagination/vehicle-table-pagination.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-pagination/vehicle-table-pagination.spec.ts
@@ -1,29 +1,36 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
-import { Auth} from '@angular/fire/auth';
+import { Auth } from '@angular/fire/auth';
+import { signal } from '@angular/core';
 
 import { VehicleTablePaginationComponent } from './vehicle-table-pagination';
+import { VehicleService } from '../../data-access/vehicle-service';
+import { VehicleInterface } from '../../interfaces/vehicle/vehicle';
+
+const authMock = {
+  currentUser: {
+    uid: 'JordiTheBest',
+    getIdToken: () => Promise.resolve('MyToken')
+  }
+};
+
+const vehicleServiceMock = {
+  vehicles: signal<VehicleInterface[]>([])
+};
 
 describe('VehicleTablePaginationComponent', () => {
   let component: VehicleTablePaginationComponent;
   let fixture: ComponentFixture<VehicleTablePaginationComponent>;
-
-  const authMock = {
-    currentUser: {
-      uid: 'JordiTheBest',
-      getIdToken: () => Promise.resolve('MyToken')
-    }
-  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [VehicleTablePaginationComponent],
       providers: [
         { provide: Auth, useValue: authMock },
+        { provide: VehicleService, useValue: vehicleServiceMock },
         provideRouter([]),
       ]
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(VehicleTablePaginationComponent);
     component = fixture.componentInstance;
@@ -33,4 +40,35 @@ describe('VehicleTablePaginationComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('initial state', () => {
+
+    it('should expose vehicles from VehicleService');
+
+  });
+
+  describe('template rendering', () => {
+
+    it('should render the nav with correct role and aria-label');
+
+    it('should render vehicle count from vehicles signal');
+
+    it('should render previous page button');
+
+    it('should render next page button');
+
+  });
+
+  describe('accessibility', () => {
+
+    it('should have aria-label on previous page button');
+
+    it('should have aria-label on next page button');
+
+    it('should have aria-live on vehicle count spans');
+
+    it('should have aria-hidden on pagination icons');
+
+  });
+
 });

--- a/src/app/features/vehicle/components/vehicle-table-pagination/vehicle-table-pagination.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-pagination/vehicle-table-pagination.spec.ts
@@ -51,13 +51,35 @@ describe('VehicleTablePaginationComponent', () => {
 
   describe('template rendering', () => {
 
-    it('should render the nav with correct role and aria-label');
+    it('should render the nav with correct role and aria-label', () => {
+      const nav = fixture.nativeElement.querySelector('nav');
 
-    it('should render vehicle count from vehicles signal');
+      expect(nav).toBeTruthy();
+      expect(nav.getAttribute('role')).toBe('navigation');
+      expect(nav.getAttribute('aria-label')).toBe(component.paginationMsg.aria.navigation);
+    });
 
-    it('should render previous page button');
+    it('should render vehicle count from vehicles signal', () => {
+      vehicleServiceMock.vehicles.set([
+        { _id: '1', name: 'Ferrari', model: 'F8', plate: '123XC' },
+        { _id: '2', name: 'Pagani', model: 'Huayra', plate: '456YZ' }
+      ]);
+      fixture.detectChanges();
 
-    it('should render next page button');
+      const values = fixture.nativeElement.querySelectorAll('.vehicle-pagination__value');
+      expect(values[0].textContent.trim()).toBe('2');
+      expect(values[1].textContent.trim()).toBe('2');
+    });
+
+    it('should render previous page button', () => {
+      const button = fixture.nativeElement.querySelector('.vehicle-pagination__button:first-of-type');
+      expect(button).toBeTruthy();
+    });
+
+    it('should render next page button', () => {
+      const buttons = fixture.nativeElement.querySelectorAll('.vehicle-pagination__button');
+      expect(buttons.length).toBe(2);
+    });
 
   });
 

--- a/src/app/features/vehicle/components/vehicle-table-pagination/vehicle-table-pagination.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-pagination/vehicle-table-pagination.spec.ts
@@ -43,7 +43,9 @@ describe('VehicleTablePaginationComponent', () => {
 
   describe('initial state', () => {
 
-    it('should expose vehicles from VehicleService');
+    it('should expose vehicles from VehicleService', () => {
+      expect(component.vehicles).toBe(vehicleServiceMock.vehicles);
+    });
 
   });
 


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/pull/120)

## Summary
Add the initial test suite for `VehicleTablePaginationComponent` covering the current implementation, which shows vehicle count but does not yet have real pagination logic.

---

## What's included
- Replaced `RouterTestingModule` with `provideRouter([])`.
- Mocked `VehicleService` to control the vehicles signal in tests.
- Added `initial state` describe verifying the vehicles signal is correctly exposed.
- Added `template rendering` describe covering nav role, vehicle count display and pagination buttons.
- Added `accessibility` describe covering aria-label, aria-live and aria-hidden attributes.

---

## Notes
- No production code changes.
- Pagination logic is not yet implemented — these tests cover only the current state of the component.
- Tests will need to be extended when real pagination (currentPage, pageSize, totalCount) is added.