### PR TITLE
test(vehicle-table): fix signal hacks, add missing coverage and extract shared mocks (#122)

### DIFF
--- a/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { signal, WritableSignal } from '@angular/core';
 import { Auth } from '@angular/fire/auth';
 
 import { VehicleTableComponent } from './vehicle-table';
@@ -32,6 +31,9 @@ describe('VehicleTableComponent', () => {
   let fixture: ComponentFixture<VehicleTableComponent>;
 
   beforeEach(async () => {
+    permissionServiceMock.isOwner.calls.reset();
+    mockVehicleModal.openEdit.calls.reset();
+
     await TestBed.configureTestingModule({
       imports: [VehicleTableComponent],
       providers: [
@@ -52,20 +54,29 @@ describe('VehicleTableComponent', () => {
   });
 
   describe('inputs', () => {
-    it('should accept vehicles input as signal', () => {
-      const vehiclesSignal: WritableSignal<VehicleInterface[]> = signal(mockVehicles);
-      (component.vehicles as any) = vehiclesSignal;
 
-      expect(component.vehicles()).toBe(mockVehicles);
+    it('should accept vehicles input', () => {
+      fixture.componentRef.setInput('vehicles', mockVehicles);
+      fixture.detectChanges();
+
+      expect(component.vehicles()).toEqual(mockVehicles);
     });
 
     it('should accept vehicleModal input', () => {
-      (component.vehicleModal as any) = () => mockVehicleModal;
+      fixture.componentRef.setInput('vehicleModal', mockVehicleModal);
+      fixture.detectChanges();
+
       expect(component.vehicleModal()).toBe(mockVehicleModal);
     });
   });
 
   describe('template rendering', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('vehicles', mockVehicles);
+      fixture.componentRef.setInput('vehicleModal', mockVehicleModal);
+      fixture.detectChanges();
+    });
+
     it('should render the table element', () => {
       const table = fixture.nativeElement.querySelector('table');
       expect(table).toBeTruthy();
@@ -82,17 +93,11 @@ describe('VehicleTableComponent', () => {
     });
 
     it('should render one table row per vehicle', () => {
-      (component.vehicles as any) = () => mockVehicles;
-      fixture.detectChanges();
-
       const rows = fixture.nativeElement.querySelectorAll('tbody tr');
       expect(rows.length).toBe(mockVehicles.length);
     });
 
     it('should render vehicle name, model and plate in each row', () => {
-      (component.vehicles as any) = () => mockVehicles;
-      fixture.detectChanges();
-
       const textContent = fixture.nativeElement.textContent;
 
       expect(textContent).toContain(mockVehicles[0].name);
@@ -105,9 +110,6 @@ describe('VehicleTableComponent', () => {
     });
 
     it('should render edit and delete buttons for owner vehicles', () => {
-      (component.vehicles as any) = () => mockVehicles;
-      fixture.detectChanges();
-
       const editButtons = fixture.nativeElement.querySelectorAll('app-edit-button');
       const deleteButtons = fixture.nativeElement.querySelectorAll('app-delete-button');
 
@@ -117,20 +119,19 @@ describe('VehicleTableComponent', () => {
   });
 
   describe('actions', () => {
-    it('should call vehicleModal.openEdit when edit button emits edit', () => {
-      (component.vehicles as any) = () => mockVehicles;
-      (component.vehicleModal as any) = () => mockVehicleModal;
+    beforeEach(() => {
+      fixture.componentRef.setInput('vehicles', mockVehicles);
+      fixture.componentRef.setInput('vehicleModal', mockVehicleModal);
       fixture.detectChanges();
+    });
 
+    it('should call vehicleModal.openEdit when edit button emits edit', () => {
       component.vehicleModal().openEdit(mockVehicles[0]);
 
       expect(mockVehicleModal.openEdit).toHaveBeenCalledWith(mockVehicles[0]);
     });
 
     it('should emit deleteVehicle when delete button emits delete', () => {
-      (component.vehicles as any) = () => mockVehicles;
-      fixture.detectChanges();
-
       spyOn(component.deleteVehicle, 'emit');
 
       component.deleteVehicle.emit(mockVehicles[0]);
@@ -141,11 +142,12 @@ describe('VehicleTableComponent', () => {
 
   describe('@for tracking', () => {
     it('should track rows by vehicle plate', () => {
-      (component.vehicles as any) = () => mockVehicles;
+      fixture.componentRef.setInput('vehicles', mockVehicles);
       fixture.detectChanges();
 
       const rowsBefore = fixture.nativeElement.querySelectorAll('tbody tr');
-      (component.vehicles as any) = () => [mockVehicles[1], mockVehicles[0]];
+
+      fixture.componentRef.setInput('vehicles', [mockVehicles[1], mockVehicles[0]]);
       fixture.detectChanges();
 
       const rowsAfter = fixture.nativeElement.querySelectorAll('tbody tr');

--- a/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
@@ -227,13 +227,43 @@ describe('VehicleTableComponent', () => {
 
   describe('accessibility', () => {
 
-    it('should have a caption for the table');
+    beforeEach(() => {
+      fixture.componentRef.setInput('vehicles', mockVehicles);
+      fixture.componentRef.setInput('vehicleModal', mockVehicleModal);
+      fixture.detectChanges();
+    });
 
-    it('should have scope col on header cells');
+    it('should have a caption for the table', () => {
+      const caption = fixture.nativeElement.querySelector('caption');
 
-    it('should have scope row on name cell');
+      expect(caption).toBeTruthy();
+      expect(caption.textContent).toContain(component.tableMsg.captionText);
+    });
 
-    it('should have aria-hidden on plate span inside name cell');
+    it('should have scope col on header cells', () => {
+      const headers = fixture.nativeElement.querySelectorAll('thead th');
+
+      headers.forEach((th: HTMLElement) => {
+        expect(th.getAttribute('scope')).toBe('col');
+      });
+    });
+
+    it('should have scope row on name cell', () => {
+      const nameHeaders = fixture.nativeElement.querySelectorAll('.vehicle-table__cell--name');
+
+      nameHeaders.forEach((th: HTMLElement) => {
+        expect(th.getAttribute('scope')).toBe('row');
+      });
+    });
+
+    it('should have aria-hidden on plate span inside name cell', () => {
+      const nameCells = fixture.nativeElement.querySelectorAll('.vehicle-table__cell--name');
+
+      nameCells.forEach((cell: HTMLElement) => {
+        const plateSpan = cell.querySelector('.vehicle-table__plate');
+        expect(plateSpan?.getAttribute('aria-hidden')).toBe('true');
+      });
+    });
 
   });
 

--- a/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
@@ -48,9 +48,11 @@ describe('VehicleTableComponent', () => {
   });
 
   describe('component creation', () => {
+
     it('should create', () => {
       expect(component).toBeTruthy();
     });
+
   });
 
   describe('inputs', () => {
@@ -68,9 +70,11 @@ describe('VehicleTableComponent', () => {
 
       expect(component.vehicleModal()).toBe(mockVehicleModal);
     });
+
   });
 
   describe('template rendering', () => {
+
     beforeEach(() => {
       permissionServiceMock.isOwner.and.returnValue(true);
       fixture.componentRef.setInput('vehicles', mockVehicles);
@@ -117,9 +121,11 @@ describe('VehicleTableComponent', () => {
       expect(editButtons.length).toBe(mockVehicles.length);
       expect(deleteButtons.length).toBe(mockVehicles.length);
     });
+
   });
 
   describe('actions', () => {
+
     beforeEach(() => {
       fixture.componentRef.setInput('vehicles', mockVehicles);
       fixture.componentRef.setInput('vehicleModal', mockVehicleModal);
@@ -139,9 +145,11 @@ describe('VehicleTableComponent', () => {
 
       expect(component.deleteVehicle.emit).toHaveBeenCalledWith(mockVehicles[0]);
     });
+
   });
 
   describe('@for tracking', () => {
+
     it('should track rows by vehicle plate', () => {
       fixture.componentRef.setInput('vehicles', mockVehicles);
       fixture.detectChanges();
@@ -154,6 +162,7 @@ describe('VehicleTableComponent', () => {
       const rowsAfter = fixture.nativeElement.querySelectorAll('tbody tr');
       expect(rowsAfter.length).toBe(rowsBefore.length);
     });
+    
   });
 
   describe('isOwner', () => {

--- a/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
@@ -157,11 +157,32 @@ describe('VehicleTableComponent', () => {
 
   describe('isOwner', () => {
 
-    it('should return true when permission service returns true');
+    it('should return true when permission service returns true', () => {
+      permissionServiceMock.isOwner.and.returnValue(true);
 
-    it('should return false when permission service returns false');
+      expect(component.isOwner(mockVehicles[0])).toBeTrue();
+      expect(permissionServiceMock.isOwner).toHaveBeenCalledWith(mockVehicles[0]);
+    });
 
-    it('should not render edit and delete buttons when user is not owner');
+    it('should return false when permission service returns false', () => {
+      permissionServiceMock.isOwner.and.returnValue(false);
+
+      expect(component.isOwner(mockVehicles[0])).toBeFalse();
+    });
+
+    it('should not render edit and delete buttons when user is not owner', () => {
+      permissionServiceMock.isOwner.and.returnValue(false);
+
+      fixture.componentRef.setInput('vehicles', mockVehicles);
+      fixture.componentRef.setInput('vehicleModal', mockVehicleModal);
+      fixture.detectChanges();
+
+      const editButtons = fixture.nativeElement.querySelectorAll('app-edit-button');
+      const deleteButtons = fixture.nativeElement.querySelectorAll('app-delete-button');
+
+      expect(editButtons.length).toBe(0);
+      expect(deleteButtons.length).toBe(0);
+    });
 
   });
 

--- a/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
@@ -204,9 +204,24 @@ describe('VehicleTableComponent', () => {
 
   describe('template: image', () => {
 
-    it('should render vehicle image with correct alt text');
+    beforeEach(() => {
+      fixture.componentRef.setInput('vehicles', mockVehicles);
+      fixture.componentRef.setInput('vehicleModal', mockVehicleModal);
+      fixture.detectChanges();
+    });
 
-    it('should use fallback image when vehicle has no imageUrl');
+    it('should render vehicle image with correct alt text', () => {
+      const images = fixture.nativeElement.querySelectorAll('.vehicle-table__image');
+
+      expect(images[0].getAttribute('alt')).toBe(`Image of ${mockVehicles[0].name}`);
+      expect(images[1].getAttribute('alt')).toBe(`Image of ${mockVehicles[1].name}`);
+    });
+
+    it('should use fallback image when vehicle has no imageUrl', () => {
+      const images = fixture.nativeElement.querySelectorAll('.vehicle-table__image');
+
+      expect(images[0].getAttribute('src')).toBe(component.vehicleImage);
+    });
 
   });
 

--- a/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
@@ -72,6 +72,7 @@ describe('VehicleTableComponent', () => {
 
   describe('template rendering', () => {
     beforeEach(() => {
+      permissionServiceMock.isOwner.and.returnValue(true);
       fixture.componentRef.setInput('vehicles', mockVehicles);
       fixture.componentRef.setInput('vehicleModal', mockVehicleModal);
       fixture.detectChanges();

--- a/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
@@ -155,4 +155,40 @@ describe('VehicleTableComponent', () => {
     });
   });
 
+  describe('isOwner', () => {
+
+    it('should return true when permission service returns true');
+
+    it('should return false when permission service returns false');
+
+    it('should not render edit and delete buttons when user is not owner');
+
+  });
+
+  describe('addUserToVehicle output', () => {
+
+    it('should emit addUserToVehicle when user button emits user');
+
+  });
+
+  describe('template: image', () => {
+
+    it('should render vehicle image with correct alt text');
+
+    it('should use fallback image when vehicle has no imageUrl');
+
+  });
+
+  describe('accessibility', () => {
+
+    it('should have a caption for the table');
+
+    it('should have scope col on header cells');
+
+    it('should have scope row on name cell');
+
+    it('should have aria-hidden on plate span inside name cell');
+
+  });
+
 });

--- a/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
@@ -188,7 +188,17 @@ describe('VehicleTableComponent', () => {
 
   describe('addUserToVehicle output', () => {
 
-    it('should emit addUserToVehicle when user button emits user');
+    it('should emit addUserToVehicle when user button emits user', () => {
+      fixture.componentRef.setInput('vehicles', mockVehicles);
+      fixture.componentRef.setInput('vehicleModal', mockVehicleModal);
+      fixture.detectChanges();
+
+      const emitSpy = spyOn(component.addUserToVehicle, 'emit');
+
+      component.addUserToVehicle.emit(mockVehicles[0]);
+
+      expect(emitSpy).toHaveBeenCalledWith(mockVehicles[0]);
+    });
 
   });
 

--- a/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
@@ -7,29 +7,29 @@ import { VehicleTableComponent } from './vehicle-table';
 import { AuthorizationService } from '../../../../core/services/authorization/authorization-service';
 import { VehicleInterface } from '../../interfaces/vehicle/vehicle';
 
+const authMock = {
+  currentUser: {
+    uid: 'JordiTheBest',
+    getIdToken: () => Promise.resolve('MyToken')
+  }
+};
+
+const permissionServiceMock = {
+  isOwner: jasmine.createSpy('isOwner').and.returnValue(true)
+};
+
+const mockVehicles: VehicleInterface[] = [
+  { _id: '1', name: 'Ferrari', model: 'F8', plate: 'F123', location: { lat: 41, lng: 2 }, userId: 'JordiTheBest' },
+  { _id: '2', name: 'Lamborghini', model: 'Huracan', plate: 'L456', location: { lat: 42, lng: 3 }, userId: 'JordiTheBest' }
+];
+
+const mockVehicleModal = {
+  openEdit: jasmine.createSpy('openEdit')
+};
+
 describe('VehicleTableComponent', () => {
   let component: VehicleTableComponent;
   let fixture: ComponentFixture<VehicleTableComponent>;
-
-  const authMock = {
-    currentUser: {
-      uid: 'JordiTheBest',
-      getIdToken: () => Promise.resolve('MyToken')
-    }
-  };
-
-  const permissionServiceMock = {
-    isOwner: jasmine.createSpy('isOwner').and.returnValue(true)
-  };
-
-  const mockVehicles: VehicleInterface[] = [
-    { _id: '1', name: 'Ferrari', model: 'F8', plate: 'F123', location: { lat: 41, lng: 2 }, userId: 'JordiTheBest' },
-    { _id: '2', name: 'Lamborghini', model: 'Huracan', plate: 'L456', location: { lat: 42, lng: 3 }, userId: 'JordiTheBest' }
-  ];
-
-  const mockVehicleModal = {
-    openEdit: jasmine.createSpy('openEdit')
-  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/pull/122)

## Summary
Fix brittle test patterns in `VehicleTableComponent`, extract shared mocks and add missing coverage for `isOwner`, `addUserToVehicle`, image rendering and accessibility.

---

## What's included
- Extracted `mockVehicles`, `mockVehicleModal` and `authMock` as shared constants.
- Added spy resets in `beforeEach` to avoid state leaking between tests.
- Replaced `(component.vehicles as any) = () => mockVehicles` signal hacks with `fixture.componentRef.setInput()`.
- Added `beforeEach` with `setInput` in `template rendering` and `actions` to avoid repetition.
- Added `isOwner` describe covering true/false cases and conditional button rendering.
- Added `addUserToVehicle` output test.
- Added `template: image` describe covering alt text and fallback image.
- Added `accessibility` describe covering caption, scope attributes and aria-hidden.
- Fixed `template rendering` `beforeEach` to explicitly set `isOwner` return value.

---

## Notes
- No production code changes.
- `isOwner` is tested both directly and through template rendering to cover both paths.