### PR TITLE
feat(vehicle-service): enable vehicle mock in service (#201)

### DIFF
--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -17,6 +17,8 @@ export class VehicleService {
 
   public vehicles = signal<VehicleInterface[]>([]);
 
+  private readonly useMock = true;
+  
   loadVehicles(): void {
     this.http.get<VehicleInterface[]>(this.apiUrl)
       .subscribe({

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -33,10 +33,22 @@ export class VehicleService {
   }
 
   addVehicles(vehicle: VehicleInterface): void {
+
+    if (this.useMock) {
+      const newVehicle = {
+        ...vehicle,
+        _id: crypto.randomUUID(),
+        userId: this.auth.currentUser?.uid
+      };
+
+      this.vehicles.update(list => [...list, newVehicle]);
+      return;
+    }
+
     this.http.post<VehicleInterface>(this.apiUrl, vehicle)
-      .subscribe( vehicleCreated => {
+      .subscribe(vehicleCreated => {
         this.vehicles.update(list => [ ...list, vehicleCreated ]);
-      })
+      });
   }
 
   updateVehicle(oldVehicle: VehicleInterface, newVehicle: VehicleInterface): void {

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -52,12 +52,22 @@ export class VehicleService {
   }
 
   updateVehicle(oldVehicle: VehicleInterface, newVehicle: VehicleInterface): void {
+
+    if (this.useMock) {
+      this.vehicles.update(list =>
+        list.map(v =>
+          v._id === oldVehicle._id ? { ...v, ...newVehicle } : v
+        )
+      );
+      return;
+    }
+
     this.http.put<VehicleInterface>(
       `${this.apiUrl}/${oldVehicle._id}`,
       newVehicle
-    ).subscribe( updatedVehicle => {
-      this.vehicles.update( list => 
-        list.map( v => v._id === oldVehicle._id 
+    ).subscribe(updatedVehicle => {
+      this.vehicles.update(list => 
+        list.map(v => v._id === oldVehicle._id 
           ? updatedVehicle
           : v
         )

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -4,6 +4,8 @@ import { HttpClient } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
 import { Auth } from '@angular/fire/auth';
 
+import { MOCK_VEHICLES } from './mocks/vehicle.mock';
+
 @Injectable({
   providedIn: 'root',
 })

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -17,11 +17,20 @@ export class VehicleService {
 
   public vehicles = signal<VehicleInterface[]>([]);
 
-  private readonly useMock = true;
+  private readonly useMock = false;
 
   loadVehicles(): void {
     if (this.useMock) {
-      this.vehicles.set(MOCK_VEHICLES);
+
+      const uid = this.auth.currentUser?.uid;
+
+      this.vehicles.set(
+        MOCK_VEHICLES.map(v => ({
+          ...v,
+          userId: uid ?? v.userId
+        }))
+      );
+
       return;
     }
 
@@ -35,10 +44,12 @@ export class VehicleService {
   addVehicles(vehicle: VehicleInterface): void {
 
     if (this.useMock) {
+      const uid = this.auth.currentUser?.uid;
+
       const newVehicle = {
         ...vehicle,
         _id: crypto.randomUUID(),
-        userId: this.auth.currentUser?.uid
+        userId: uid ?? 'mock-user'
       };
 
       this.vehicles.update(list => [...list, newVehicle]);

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -18,8 +18,13 @@ export class VehicleService {
   public vehicles = signal<VehicleInterface[]>([]);
 
   private readonly useMock = true;
-  
+
   loadVehicles(): void {
+    if (this.useMock) {
+      this.vehicles.set(MOCK_VEHICLES);
+      return;
+    }
+
     this.http.get<VehicleInterface[]>(this.apiUrl)
       .subscribe({
         next: vehicles => this.vehicles.set(vehicles),

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -107,6 +107,14 @@ export class VehicleService {
   }
 
   deleteVehicle(vehicle: VehicleInterface): void {
+
+    if (this.useMock) {
+      this.vehicles.update(list =>
+        list.filter(v => v._id !== vehicle._id)
+      );
+      return;
+    }
+
     this.http.delete<void>(`${this.apiUrl}/${vehicle._id}`)
       .subscribe(() => {
         this.vehicles.update(list =>

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -79,6 +79,18 @@ export class VehicleService {
     vehicle: VehicleInterface,
     location: { lat: number; lng: number }
   ): void {
+
+    if (this.useMock) {
+      this.vehicles.update(list =>
+        list.map(v =>
+          v._id === vehicle._id
+            ? { ...v, location }
+            : v
+        )
+      );
+      return;
+    }
+
     const updatedLocation = { location }
 
     this.http.put<VehicleInterface>(


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/201)

## Summary

Introduced a mock mode in `VehicleService` to allow frontend development without relying on the backend API. The service now supports switching between real API calls and in-memory mock data using a feature flag, improving development speed and decoupling frontend work from backend availability.

---

## What's included

- Added `useMock` feature flag to toggle between backend and mock data
- Imported `MOCK_VEHICLES` dataset into `VehicleService`
- Updated `loadVehicles()` to support mock data loading
- Extended `addVehicles()` to support vehicle creation in mock mode with generated `_id`
- Extended `updateVehicle()` to support in-memory updates in mock mode
- Extended `updateVehicleLocation()` to support mock location updates
- Extended `deleteVehicle()` to support in-memory deletion
- Ensured all CRUD operations remain fully compatible with backend mode
- Improved `userId` handling in mock mode to correctly reflect authenticated user context