### PR TITLE
refactor(vehicle-service): extract mock logic into private methods (#210)

### DIFF
--- a/src/app/features/map/components/map-container/map-container.spec.ts
+++ b/src/app/features/map/components/map-container/map-container.spec.ts
@@ -41,7 +41,7 @@ const selectedVehicleMock: VehicleInterface = {
 const vehicleServiceMock = {
   vehicles: signal<VehicleInterface[]>([]),
   loadVehicles: jasmine.createSpy('loadVehicles'),
-  addVehicles: jasmine.createSpy('addVehicles'),
+  addVehicle: jasmine.createSpy('addVehicle'),
   updateVehicle: jasmine.createSpy('updateVehicle'),
 };
 
@@ -63,7 +63,7 @@ describe('MapContainerComponent', () => {
 
   beforeEach(async () => {
     vehicleServiceMock.loadVehicles.calls.reset();
-    vehicleServiceMock.addVehicles.calls.reset();
+    vehicleServiceMock.addVehicle.calls.reset();
     vehicleServiceMock.updateVehicle.calls.reset();
     VehicleModalServiceMock.openCreate.calls.reset();
     VehicleModalServiceMock.close.calls.reset();
@@ -115,12 +115,12 @@ describe('MapContainerComponent', () => {
     it('should keep provided location when vehicle already has location', async () => {
       VehicleModalServiceMock.formMode.set('create');
       geolocationServiceMock.getCurrentLocation.calls.reset();
-      vehicleServiceMock.addVehicles.calls.reset();
+      vehicleServiceMock.addVehicle.calls.reset();
 
       await component.saveVehicle(vehicleMock);
 
       expect(geolocationServiceMock.getCurrentLocation).not.toHaveBeenCalled();
-      expect(vehicleServiceMock.addVehicles).toHaveBeenCalledOnceWith(vehicleMock);
+      expect(vehicleServiceMock.addVehicle).toHaveBeenCalledOnceWith(vehicleMock);
       expect(VehicleModalServiceMock.close).toHaveBeenCalled();
     });
 
@@ -128,14 +128,14 @@ describe('MapContainerComponent', () => {
       VehicleModalServiceMock.formMode.set('create');
 
       geolocationServiceMock.getCurrentLocation.and.resolveTo([41.4, 2.1]);
-      vehicleServiceMock.addVehicles.calls.reset();
+      vehicleServiceMock.addVehicle.calls.reset();
 
       await component.saveVehicle(vehicleWithoutLocation as any);
 
       expect(geolocationServiceMock.getCurrentLocation).toHaveBeenCalled();
-      expect(vehicleServiceMock.addVehicles).toHaveBeenCalled();
+      expect(vehicleServiceMock.addVehicle).toHaveBeenCalled();
 
-      const addedVehicle = vehicleServiceMock.addVehicles.calls.mostRecent().args[0];
+      const addedVehicle = vehicleServiceMock.addVehicle.calls.mostRecent().args[0];
 
       expect(addedVehicle.location).toEqual({ lat: 41.4, lng: 2.1 });
       expect(VehicleModalServiceMock.close).toHaveBeenCalled();
@@ -146,11 +146,11 @@ describe('MapContainerComponent', () => {
       geolocationServiceMock.getCurrentLocation.and.returnValue(
         Promise.reject(new Error('geolocation failed'))
       );
-      vehicleServiceMock.addVehicles.calls.reset();
+      vehicleServiceMock.addVehicle.calls.reset();
 
       await component.saveVehicle(vehicleWithoutLocation as any);
 
-      const addedVehicle = vehicleServiceMock.addVehicles.calls.mostRecent().args[0];
+      const addedVehicle = vehicleServiceMock.addVehicle.calls.mostRecent().args[0];
 
       expect(addedVehicle.location).toEqual({ lat: 41.478, lng: 2.31 });
       expect(VehicleModalServiceMock.close).toHaveBeenCalled();
@@ -158,12 +158,12 @@ describe('MapContainerComponent', () => {
 
     it('should add vehicle when modal mode is create', async () => {
       VehicleModalServiceMock.formMode.set('create');
-      vehicleServiceMock.addVehicles.calls.reset();
+      vehicleServiceMock.addVehicle.calls.reset();
       vehicleServiceMock.updateVehicle.calls.reset();
 
       await component.saveVehicle(vehicleMock);
 
-      expect(vehicleServiceMock.addVehicles).toHaveBeenCalledOnceWith(vehicleMock);
+      expect(vehicleServiceMock.addVehicle).toHaveBeenCalledOnceWith(vehicleMock);
       expect(vehicleServiceMock.updateVehicle).not.toHaveBeenCalled();
     });
 
@@ -173,7 +173,7 @@ describe('MapContainerComponent', () => {
 
       await component.saveVehicle(vehicleMock);
 
-      expect(vehicleServiceMock.addVehicles).not.toHaveBeenCalled();
+      expect(vehicleServiceMock.addVehicle).not.toHaveBeenCalled();
       expect(vehicleServiceMock.updateVehicle).toHaveBeenCalledOnceWith(selectedVehicleMock, vehicleMock);
     });
 
@@ -185,7 +185,7 @@ describe('MapContainerComponent', () => {
       await component.saveVehicle(vehicleMock);
 
       expect(vehicleServiceMock.updateVehicle).not.toHaveBeenCalled();
-      expect(vehicleServiceMock.addVehicles).not.toHaveBeenCalled();
+      expect(vehicleServiceMock.addVehicle).not.toHaveBeenCalled();
       expect(VehicleModalServiceMock.close).toHaveBeenCalled();
     });
 

--- a/src/app/features/map/components/map-container/map-container.ts
+++ b/src/app/features/map/components/map-container/map-container.ts
@@ -45,7 +45,7 @@ export class MapContainerComponent implements OnInit {
     const vehicle: VehicleInterface = { ...vehicleData, location };
 
     if (this.vehicleModal.formMode() === 'create') {
-      this.vehicleService.addVehicles(vehicle);
+      this.vehicleService.addVehicle(vehicle);
     } else if (this.vehicleModal.formMode() === 'edit') {
       const selectedVehicle = this.vehicleModal.selectedVehicle();
       if (selectedVehicle) {

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -53,7 +53,7 @@ describe('MapViewComponent', () => {
     const vehicleServiceMock = {
       vehicles: signal<VehicleInterface[]>([]),
       loadVehicles: jasmine.createSpy('loadVehicles'),
-      addVehicles: jasmine.createSpy('addVehicles'),
+      addVehicle: jasmine.createSpy('addVehicle'),
       updateVehicle: jasmine.createSpy('updateVehicle'),
       deleteVehicle: jasmine.createSpy('deleteVehicle'),
       updateVehicleLocation: jasmine.createSpy('updateVehicleLocation')

--- a/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
@@ -21,7 +21,7 @@ const authMock = {
 const vehicleServiceMock = {
   vehicles: signal<VehicleInterface[]>([]),
   loadVehicles: jasmine.createSpy('loadVehicles'),
-  addVehicles: jasmine.createSpy('addVehicles'),
+  addVehicle: jasmine.createSpy('addVehicle'),
   updateVehicle: jasmine.createSpy('updateVehicle'),
   deleteVehicle: jasmine.createSpy('deleteVehicle'),
   addUserToVehicle: jasmine.createSpy('addUserToVehicle'),
@@ -63,7 +63,7 @@ describe('VehicleViewComponent', () => {
 
   beforeEach(async () => {
     vehicleServiceMock.loadVehicles.calls.reset();
-    vehicleServiceMock.addVehicles.calls.reset();
+    vehicleServiceMock.addVehicle.calls.reset();
     vehicleServiceMock.updateVehicle.calls.reset();
     vehicleServiceMock.deleteVehicle.calls.reset();
     vehicleServiceMock.addUserToVehicle.calls.reset();
@@ -141,7 +141,7 @@ describe('VehicleViewComponent', () => {
       await component.saveVehicle(vehicleWithoutLocationMock);
 
       expect(geolocationServiceMock.getCurrentLocation).toHaveBeenCalled();
-      expect(vehicleServiceMock.addVehicles).toHaveBeenCalledWith({
+      expect(vehicleServiceMock.addVehicle).toHaveBeenCalledWith({
         ...vehicleWithoutLocationMock,
         location: { lat: 41.5, lng: 2.3 }
       });
@@ -153,18 +153,18 @@ describe('VehicleViewComponent', () => {
 
       await component.saveVehicle(vehicleWithoutLocationMock);
 
-      expect(vehicleServiceMock.addVehicles).toHaveBeenCalledWith({
+      expect(vehicleServiceMock.addVehicle).toHaveBeenCalledWith({
         ...vehicleWithoutLocationMock,
         location: { lat: 41.402, lng: 2.194 }
       });
     });
 
-    it('should call addVehicles when mode is create', async () => {
+    it('should call addVehicle when mode is create', async () => {
       VehicleModalServiceMock.formMode.set('create');
 
       await component.saveVehicle(vehicleMock);
 
-      expect(vehicleServiceMock.addVehicles).toHaveBeenCalledWith(vehicleMock);
+      expect(vehicleServiceMock.addVehicle).toHaveBeenCalledWith(vehicleMock);
     });
 
     it('should call updateVehicle when mode is edit', async () => {

--- a/src/app/features/vehicle/components/vehicle-view/vehicle-view.ts
+++ b/src/app/features/vehicle/components/vehicle-view/vehicle-view.ts
@@ -110,7 +110,7 @@ export class VehicleViewComponent implements OnInit {
       location
     };
 
-    this.vehicleService.addVehicles(vehicleToSend);
+    this.vehicleService.addVehicle(vehicleToSend);
   }
 
   private updateVehicle(vehicleData: VehicleInterface): void {

--- a/src/app/features/vehicle/data-access/vehicle-service.spec.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.spec.ts
@@ -425,7 +425,17 @@ describe('VehicleService', () => {
 
   describe('updateVehicleLocation (mock)', () => {
 
-    it('should update vehicle location in signal without HTTP call when useMock is true');
+    beforeEach(() => {
+      (service as any).useMock = true;
+      service.vehicles.set([ferrariMock]);
+    });
+
+    it('should update vehicle location in signal without HTTP call when useMock is true', () => {
+      service.updateVehicleLocation(ferrariMock, { lat: 99, lng: 88 });
+
+      expect(service.vehicles()[0].location).toEqual({ lat: 99, lng: 88 });
+      expect(httpMock.match(`${API_URL}/1`).length).toBe(0);
+    });
 
   });
 

--- a/src/app/features/vehicle/data-access/vehicle-service.spec.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.spec.ts
@@ -114,6 +114,30 @@ describe('VehicleService', () => {
 
   });
 
+  describe('loadVehicles (mock)', () => {
+
+    beforeEach(() => {
+      (service as any).useMock = true;
+    });
+
+    it('should load mock vehicles when useMock is true', () => {
+      service.loadVehicles();
+
+      expect(service.vehicles().length).toBeGreaterThan(0);
+      expect(httpMock.match(API_URL).length).toBe(0);
+    });
+
+    it('should assign current user uid to mock vehicles', () => {
+      service.loadVehicles();
+
+      const vehicles = service.vehicles();
+      vehicles.forEach(v => {
+        expect(v.userId).toBe('JordiTheBest');
+      });
+    });
+
+  });
+
   describe('addVehicles', () => {
 
     it('should call POST /vehicles endpoint with vehicle payload', () => {
@@ -153,6 +177,29 @@ describe('VehicleService', () => {
 
   });
 
+  describe('addVehicles (mock)', () => {
+
+    beforeEach(() => {
+      (service as any).useMock = true;
+      service.vehicles.set([ferrariMock]);
+    });
+
+    it('should add vehicle to signal without HTTP call when useMock is true', () => {
+      service.addVehicles(paganiMock);
+
+      expect(service.vehicles().length).toBe(2);
+      expect(httpMock.match(API_URL).length).toBe(0);
+    });
+
+    it('should assign current user uid to new mock vehicle', () => {
+      service.addVehicles(paganiMock);
+
+      const added = service.vehicles().find(v => v.plate === paganiMock.plate);
+      expect(added?.userId).toBe('JordiTheBest');
+    });
+
+  });
+
   describe('updateVehicle', () => {
 
     it('should call PUT /vehicles/:id with updated vehicle data', () => {
@@ -178,6 +225,23 @@ describe('VehicleService', () => {
       req.flush(newVehicle);
 
       expect(service.vehicles()).toEqual([newVehicle, paganiMock]);
+    });
+
+  });
+
+    describe('updateVehicle (mock)', () => {
+
+    beforeEach(() => {
+      (service as any).useMock = true;
+      service.vehicles.set([ferrariMock]);
+    });
+
+    it('should update vehicle in signal without HTTP call when useMock is true', () => {
+      const updatedVehicle: VehicleInterface = { ...ferrariMock, model: 'F8 Spider' };
+      service.updateVehicle(ferrariMock, updatedVehicle);
+
+      expect(service.vehicles()[0].model).toBe('F8 Spider');
+      expect(httpMock.match(`${API_URL}/1`).length).toBe(0);
     });
 
   });
@@ -211,6 +275,22 @@ describe('VehicleService', () => {
 
   });
 
+  describe('updateVehicleLocation (mock)', () => {
+
+    beforeEach(() => {
+      (service as any).useMock = true;
+      service.vehicles.set([ferrariMock]);
+    });
+
+    it('should update vehicle location in signal without HTTP call when useMock is true', () => {
+      service.updateVehicleLocation(ferrariMock, { lat: 99, lng: 88 });
+
+      expect(service.vehicles()[0].location).toEqual({ lat: 99, lng: 88 });
+      expect(httpMock.match(`${API_URL}/1`).length).toBe(0);
+    });
+
+  });
+
   describe('deleteVehicle', () => {
 
     it('should call DELETE /vehicles/:id endpoint', () => {
@@ -236,6 +316,23 @@ describe('VehicleService', () => {
       expect(service.vehicles().length).toBe(1);
       expect(service.vehicles()[0]._id).toBe('2');
       expect(service.vehicles()[0].name).toBe('Pagani');
+    });
+
+  });
+
+  describe('deleteVehicle (mock)', () => {
+
+    beforeEach(() => {
+      (service as any).useMock = true;
+      service.vehicles.set([ferrariMock, paganiMock]);
+    });
+
+    it('should remove vehicle from signal without HTTP call when useMock is true', () => {
+      service.deleteVehicle(ferrariMock);
+
+      expect(service.vehicles().length).toBe(1);
+      expect(service.vehicles()[0]._id).toBe('2');
+      expect(httpMock.match(`${API_URL}/1`).length).toBe(0);
     });
 
   });
@@ -355,103 +452,6 @@ describe('VehicleService', () => {
       req.flush(null);
 
       expect(service.vehicles()[1]).toEqual(paganiMock);
-    });
-
-  });
-
-  describe('loadVehicles (mock)', () => {
-
-    beforeEach(() => {
-      (service as any).useMock = true;
-    });
-
-    it('should load mock vehicles when useMock is true', () => {
-      service.loadVehicles();
-
-      expect(service.vehicles().length).toBeGreaterThan(0);
-      expect(httpMock.match(API_URL).length).toBe(0);
-    });
-
-    it('should assign current user uid to mock vehicles', () => {
-      service.loadVehicles();
-
-      const vehicles = service.vehicles();
-      vehicles.forEach(v => {
-        expect(v.userId).toBe('JordiTheBest');
-      });
-    });
-
-  });
-
-  describe('addVehicles (mock)', () => {
-
-    beforeEach(() => {
-      (service as any).useMock = true;
-      service.vehicles.set([ferrariMock]);
-    });
-
-    it('should add vehicle to signal without HTTP call when useMock is true', () => {
-      service.addVehicles(paganiMock);
-
-      expect(service.vehicles().length).toBe(2);
-      expect(httpMock.match(API_URL).length).toBe(0);
-    });
-
-    it('should assign current user uid to new mock vehicle', () => {
-      service.addVehicles(paganiMock);
-
-      const added = service.vehicles().find(v => v.plate === paganiMock.plate);
-      expect(added?.userId).toBe('JordiTheBest');
-    });
-
-  });
-
-  describe('updateVehicle (mock)', () => {
-
-    beforeEach(() => {
-      (service as any).useMock = true;
-      service.vehicles.set([ferrariMock]);
-    });
-
-    it('should update vehicle in signal without HTTP call when useMock is true', () => {
-      const updatedVehicle: VehicleInterface = { ...ferrariMock, model: 'F8 Spider' };
-      service.updateVehicle(ferrariMock, updatedVehicle);
-
-      expect(service.vehicles()[0].model).toBe('F8 Spider');
-      expect(httpMock.match(`${API_URL}/1`).length).toBe(0);
-    });
-
-  });
-
-  describe('updateVehicleLocation (mock)', () => {
-
-    beforeEach(() => {
-      (service as any).useMock = true;
-      service.vehicles.set([ferrariMock]);
-    });
-
-    it('should update vehicle location in signal without HTTP call when useMock is true', () => {
-      service.updateVehicleLocation(ferrariMock, { lat: 99, lng: 88 });
-
-      expect(service.vehicles()[0].location).toEqual({ lat: 99, lng: 88 });
-      expect(httpMock.match(`${API_URL}/1`).length).toBe(0);
-    });
-
-  });
-
-  describe('deleteVehicle (mock)', () => {
-
-    beforeEach(() => {
-      (service as any).useMock = true;
-      service.vehicles.set([ferrariMock, paganiMock]);
-    });
-
-    it('should remove vehicle from signal without HTTP call when useMock is true', () => {
-      service.deleteVehicle(ferrariMock);
-
-      expect(service.vehicles().length).toBe(1);
-      expect(service.vehicles()[0]._id).toBe('2');
-      expect(httpMock.match(`${API_URL}/1`).length).toBe(0);
     });
 
   });

--- a/src/app/features/vehicle/data-access/vehicle-service.spec.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.spec.ts
@@ -361,9 +361,25 @@ describe('VehicleService', () => {
 
   describe('loadVehicles (mock)', () => {
 
-    it('should load mock vehicles when useMock is true');
+    beforeEach(() => {
+      (service as any).useMock = true;
+    });
 
-    it('should assign current user uid to mock vehicles');
+    it('should load mock vehicles when useMock is true', () => {
+      service.loadVehicles();
+
+      expect(service.vehicles().length).toBeGreaterThan(0);
+      expect(httpMock.match(API_URL).length).toBe(0);
+    });
+
+    it('should assign current user uid to mock vehicles', () => {
+      service.loadVehicles();
+
+      const vehicles = service.vehicles();
+      vehicles.forEach(v => {
+        expect(v.userId).toBe('JordiTheBest');
+      });
+    });
 
   });
 

--- a/src/app/features/vehicle/data-access/vehicle-service.spec.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.spec.ts
@@ -359,4 +359,38 @@ describe('VehicleService', () => {
 
   });
 
+  describe('loadVehicles (mock)', () => {
+
+    it('should load mock vehicles when useMock is true');
+
+    it('should assign current user uid to mock vehicles');
+
+  });
+
+  describe('addVehicles (mock)', () => {
+
+    it('should add vehicle to signal without HTTP call when useMock is true');
+
+    it('should assign current user uid to new mock vehicle');
+
+  });
+
+  describe('updateVehicle (mock)', () => {
+
+    it('should update vehicle in signal without HTTP call when useMock is true');
+
+  });
+
+  describe('updateVehicleLocation (mock)', () => {
+
+    it('should update vehicle location in signal without HTTP call when useMock is true');
+
+  });
+
+  describe('deleteVehicle (mock)', () => {
+
+    it('should remove vehicle from signal without HTTP call when useMock is true');
+
+  });
+
 });

--- a/src/app/features/vehicle/data-access/vehicle-service.spec.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.spec.ts
@@ -408,7 +408,18 @@ describe('VehicleService', () => {
 
   describe('updateVehicle (mock)', () => {
 
-    it('should update vehicle in signal without HTTP call when useMock is true');
+    beforeEach(() => {
+      (service as any).useMock = true;
+      service.vehicles.set([ferrariMock]);
+    });
+
+    it('should update vehicle in signal without HTTP call when useMock is true', () => {
+      const updatedVehicle: VehicleInterface = { ...ferrariMock, model: 'F8 Spider' };
+      service.updateVehicle(ferrariMock, updatedVehicle);
+
+      expect(service.vehicles()[0].model).toBe('F8 Spider');
+      expect(httpMock.match(`${API_URL}/1`).length).toBe(0);
+    });
 
   });
 

--- a/src/app/features/vehicle/data-access/vehicle-service.spec.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.spec.ts
@@ -385,9 +385,24 @@ describe('VehicleService', () => {
 
   describe('addVehicles (mock)', () => {
 
-    it('should add vehicle to signal without HTTP call when useMock is true');
+    beforeEach(() => {
+      (service as any).useMock = true;
+      service.vehicles.set([ferrariMock]);
+    });
 
-    it('should assign current user uid to new mock vehicle');
+    it('should add vehicle to signal without HTTP call when useMock is true', () => {
+      service.addVehicles(paganiMock);
+
+      expect(service.vehicles().length).toBe(2);
+      expect(httpMock.match(API_URL).length).toBe(0);
+    });
+
+    it('should assign current user uid to new mock vehicle', () => {
+      service.addVehicles(paganiMock);
+
+      const added = service.vehicles().find(v => v.plate === paganiMock.plate);
+      expect(added?.userId).toBe('JordiTheBest');
+    });
 
   });
 

--- a/src/app/features/vehicle/data-access/vehicle-service.spec.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.spec.ts
@@ -441,7 +441,18 @@ describe('VehicleService', () => {
 
   describe('deleteVehicle (mock)', () => {
 
-    it('should remove vehicle from signal without HTTP call when useMock is true');
+    beforeEach(() => {
+      (service as any).useMock = true;
+      service.vehicles.set([ferrariMock, paganiMock]);
+    });
+
+    it('should remove vehicle from signal without HTTP call when useMock is true', () => {
+      service.deleteVehicle(ferrariMock);
+
+      expect(service.vehicles().length).toBe(1);
+      expect(service.vehicles()[0]._id).toBe('2');
+      expect(httpMock.match(`${API_URL}/1`).length).toBe(0);
+    });
 
   });
 

--- a/src/app/features/vehicle/data-access/vehicle-service.spec.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.spec.ts
@@ -138,10 +138,10 @@ describe('VehicleService', () => {
 
   });
 
-  describe('addVehicles', () => {
+  describe('addVehicle', () => {
 
     it('should call POST /vehicles endpoint with vehicle payload', () => {
-      service.addVehicles(ferrariMock);
+      service.addVehicle(ferrariMock);
 
       const req = httpMock.expectOne(API_URL);
       expect(req.request.method).toBe('POST');
@@ -163,7 +163,7 @@ describe('VehicleService', () => {
         }
       };
 
-      service.addVehicles(newVehicle);
+      service.addVehicle(newVehicle);
 
       const req = httpMock.expectOne(API_URL);
       expect(req.request.body).toEqual(newVehicle);
@@ -177,7 +177,7 @@ describe('VehicleService', () => {
 
   });
 
-  describe('addVehicles (mock)', () => {
+  describe('addVehicle (mock)', () => {
 
     beforeEach(() => {
       (service as any).useMock = true;
@@ -185,14 +185,14 @@ describe('VehicleService', () => {
     });
 
     it('should add vehicle to signal without HTTP call when useMock is true', () => {
-      service.addVehicles(paganiMock);
+      service.addVehicle(paganiMock);
 
       expect(service.vehicles().length).toBe(2);
       expect(httpMock.match(API_URL).length).toBe(0);
     });
 
     it('should assign current user uid to new mock vehicle', () => {
-      service.addVehicles(paganiMock);
+      service.addVehicle(paganiMock);
 
       const added = service.vehicles().find(v => v.plate === paganiMock.plate);
       expect(added?.userId).toBe('JordiTheBest');

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -38,27 +38,17 @@ export class VehicleService {
   }
 
   updateVehicle(oldVehicle: VehicleInterface, newVehicle: VehicleInterface): void {
+    if (this.useMock) return this.updateMockVehicle(oldVehicle, newVehicle);
 
-    if (this.useMock) {
-      this.vehicles.update(list =>
-        list.map(v =>
-          v._id === oldVehicle._id ? { ...v, ...newVehicle } : v
-        )
-      );
-      return;
-    }
-
-    this.http.put<VehicleInterface>(
-      `${this.apiUrl}/${oldVehicle._id}`,
-      newVehicle
-    ).subscribe(updatedVehicle => {
-      this.vehicles.update(list => 
-        list.map(v => v._id === oldVehicle._id 
-          ? updatedVehicle
-          : v
-        )
-      )
-    })
+    this.http.put<VehicleInterface>(`${this.apiUrl}/${oldVehicle._id}`, newVehicle)
+      .subscribe(updatedVehicle => {
+        this.vehicles.update(list =>
+          list.map(v => v._id === oldVehicle._id 
+            ? updatedVehicle 
+            : v
+          )
+        );
+      });
   }
 
   updateVehicleLocation(
@@ -172,6 +162,12 @@ export class VehicleService {
       userId: this.auth.currentUser?.uid ?? 'mock-user' 
     };
     this.vehicles.update(list => [...list, newVehicle]);
+  }
+
+  private updateMockVehicle(oldVehicle: VehicleInterface, newVehicle: VehicleInterface): void {
+    this.vehicles.update(list =>
+      list.map(v => v._id === oldVehicle._id ? { ...v, ...newVehicle } : v)
+    );
   }
 
 }

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -69,19 +69,11 @@ export class VehicleService {
   }
 
   deleteVehicle(vehicle: VehicleInterface): void {
-
-    if (this.useMock) {
-      this.vehicles.update(list =>
-        list.filter(v => v._id !== vehicle._id)
-      );
-      return;
-    }
+    if (this.useMock) return this.deleteMockVehicle(vehicle);
 
     this.http.delete<void>(`${this.apiUrl}/${vehicle._id}`)
       .subscribe(() => {
-        this.vehicles.update(list =>
-          list.filter(v => v._id !== vehicle._id)
-        );
+        this.vehicles.update(list => list.filter(v => v._id !== vehicle._id));
       });
   }
 
@@ -160,6 +152,10 @@ export class VehicleService {
     this.vehicles.update(list =>
       list.map(v => v._id === vehicle._id ? { ...v, location } : v)
     );
+  }
+
+  private deleteMockVehicle(vehicle: VehicleInterface): void {
+    this.vehicles.update(list => list.filter(v => v._id !== vehicle._id));
   }
 
 }

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -10,7 +10,7 @@ import { MOCK_VEHICLES } from './mocks/vehicle.mock';
   providedIn: 'root',
 })
 export class VehicleService {
-  
+
   private readonly http = inject(HttpClient);
   private readonly auth = inject(Auth);
   private readonly apiUrl = 'http://localhost:3000/vehicles';
@@ -121,8 +121,7 @@ export class VehicleService {
     );
   }
 
-  // =====================================================
-  
+
   private loadMockVehicles(): void {
     this.vehicles.set(
       MOCK_VEHICLES.map(v => ({ ...v, userId: this.auth.currentUser?.uid ?? v.userId }))

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -29,23 +29,11 @@ export class VehicleService {
   }
 
   addVehicles(vehicle: VehicleInterface): void {
-
-    if (this.useMock) {
-      const uid = this.auth.currentUser?.uid;
-
-      const newVehicle = {
-        ...vehicle,
-        _id: crypto.randomUUID(),
-        userId: uid ?? 'mock-user'
-      };
-
-      this.vehicles.update(list => [...list, newVehicle]);
-      return;
-    }
+    if (this.useMock) return this.addMockVehicle(vehicle);
 
     this.http.post<VehicleInterface>(this.apiUrl, vehicle)
       .subscribe(vehicleCreated => {
-        this.vehicles.update(list => [ ...list, vehicleCreated ]);
+        this.vehicles.update(list => [...list, vehicleCreated]);
       });
   }
 
@@ -175,6 +163,15 @@ export class VehicleService {
     this.vehicles.set(
       MOCK_VEHICLES.map(v => ({ ...v, userId: this.auth.currentUser?.uid ?? v.userId }))
     );
+  }
+
+  private addMockVehicle(vehicle: VehicleInterface): void {
+    const newVehicle = { 
+      ...vehicle, 
+      _id: crypto.randomUUID(), 
+      userId: this.auth.currentUser?.uid ?? 'mock-user' 
+    };
+    this.vehicles.update(list => [...list, newVehicle]);
   }
 
 }

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -37,7 +37,10 @@ export class VehicleService {
       });
   }
 
-  updateVehicle(oldVehicle: VehicleInterface, newVehicle: VehicleInterface): void {
+  updateVehicle(
+    oldVehicle: VehicleInterface, 
+    newVehicle: VehicleInterface
+  ): void {
     if (this.useMock) return this.updateMockVehicle(oldVehicle, newVehicle);
 
     this.http.put<VehicleInterface>(`${this.apiUrl}/${oldVehicle._id}`, newVehicle)
@@ -55,31 +58,14 @@ export class VehicleService {
     vehicle: VehicleInterface,
     location: { lat: number; lng: number }
   ): void {
+    if (this.useMock) return this.updateMockLocation(vehicle, location);
 
-    if (this.useMock) {
-      this.vehicles.update(list =>
-        list.map(v =>
-          v._id === vehicle._id
-            ? { ...v, location }
-            : v
-        )
-      );
-      return;
-    }
-
-    const updatedLocation = { location }
-
-    this.http.put<VehicleInterface>(
-      `${this.apiUrl}/${vehicle._id}`,
-      updatedLocation
-    ).subscribe(updatedVehicle => {
-      this.vehicles.update(list =>
-        list.map(v => v._id === vehicle._id 
-          ? updatedVehicle 
-          : v
-        )
-      );
-    });
+    this.http.put<VehicleInterface>(`${this.apiUrl}/${vehicle._id}`, { location })
+      .subscribe(updatedVehicle => {
+        this.vehicles.update(list =>
+          list.map(v => v._id === vehicle._id ? updatedVehicle : v)
+        );
+      });
   }
 
   deleteVehicle(vehicle: VehicleInterface): void {
@@ -167,6 +153,12 @@ export class VehicleService {
   private updateMockVehicle(oldVehicle: VehicleInterface, newVehicle: VehicleInterface): void {
     this.vehicles.update(list =>
       list.map(v => v._id === oldVehicle._id ? { ...v, ...newVehicle } : v)
+    );
+  }
+
+  private updateMockLocation(vehicle: VehicleInterface, location: { lat: number; lng: number }): void {
+    this.vehicles.update(list =>
+      list.map(v => v._id === vehicle._id ? { ...v, location } : v)
     );
   }
 

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -20,25 +20,12 @@ export class VehicleService {
   private readonly useMock = false;
 
   loadVehicles(): void {
-    if (this.useMock) {
+    if (this.useMock) return this.loadMockVehicles();
 
-      const uid = this.auth.currentUser?.uid;
-
-      this.vehicles.set(
-        MOCK_VEHICLES.map(v => ({
-          ...v,
-          userId: uid ?? v.userId
-        }))
-      );
-
-      return;
-    }
-
-    this.http.get<VehicleInterface[]>(this.apiUrl)
-      .subscribe({
-        next: vehicles => this.vehicles.set(vehicles),
-        error: err => console.error('Load vehicles error', err)
-      })
+    this.http.get<VehicleInterface[]>(this.apiUrl).subscribe({
+      next: vehicles => this.vehicles.set(vehicles),
+      error: err => console.error('Load vehicles error', err)
+    });
   }
 
   addVehicles(vehicle: VehicleInterface): void {
@@ -181,6 +168,12 @@ export class VehicleService {
           );
         }
       })
+    );
+  }
+
+  private loadMockVehicles(): void {
+    this.vehicles.set(
+      MOCK_VEHICLES.map(v => ({ ...v, userId: this.auth.currentUser?.uid ?? v.userId }))
     );
   }
 

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -28,7 +28,7 @@ export class VehicleService {
     });
   }
 
-  addVehicles(vehicle: VehicleInterface): void {
+  addVehicle(vehicle: VehicleInterface): void {
     if (this.useMock) return this.addMockVehicle(vehicle);
 
     this.http.post<VehicleInterface>(this.apiUrl, vehicle)

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -112,16 +112,10 @@ export class VehicleService {
             list.filter(v => v._id !== vehicleId)
           );
         } else {
-          this.vehicles.update(list =>
-            list.map(v =>
-              v._id === vehicleId
-                ? { 
-                    ...v, 
-                    users: (v.users ?? []).filter(user => user.userId !== userId) 
-                  }
-                : v
-            )
-          );
+          this.vehicles.update(list => list.map( v => v._id === vehicleId
+            ? { ...v, users: (v.users ?? []).filter(user => user.userId !== userId)}
+            : v
+          ));
         }
       })
     );

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -121,6 +121,8 @@ export class VehicleService {
     );
   }
 
+  // =====================================================
+  
   private loadMockVehicles(): void {
     this.vehicles.set(
       MOCK_VEHICLES.map(v => ({ ...v, userId: this.auth.currentUser?.uid ?? v.userId }))


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/pull/210)

## Summary
Extract all mock logic from public methods in `VehicleService` into dedicated private methods, making each public method shorter and easier to read.

Additionally, the service has been updated to reflect a naming refactor where `addVehicles` was renamed to `addVehicle`, and all corresponding references across the application and test suite have been updated accordingly.

---

## What's included
- Extracted `loadMockVehicles()` private method.
- Extracted `addMockVehicle()` private method.
- Extracted `updateMockVehicle()` private method.
- Extracted `updateMockLocation()` private method.
- Extracted `deleteMockVehicle()` private method.
- Renamed `addVehicles` to `addVehicle`.
- Updated all references throughout the codebaseto use the `addVehicle` method name.
- Updated all affected tests to match the new naming convention.
- Added tests for all mock methods covering signal updates and absence of HTTP calls.
- Reordered mock test describes to sit next to their corresponding method describes.

---

## Notes
- No behavior changes — `useMock` flag remains in place and works exactly as before.
- Mock methods are private and tested indirectly by setting `useMock = true` in tests.