### PR TITLE
refactor(vehicle-service): centralize currentUserId access (#212)

### DIFF
--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -17,7 +17,7 @@ export class VehicleService {
 
   public vehicles = signal<VehicleInterface[]>([]);
 
-  private readonly useMock = false;
+  private readonly useMock = true;
 
   private get currentUserId(): string | undefined {
     return this.auth.currentUser?.uid;
@@ -129,7 +129,7 @@ export class VehicleService {
 
   private loadMockVehicles(): void {
     this.vehicles.set(
-      MOCK_VEHICLES.map(v => ({ ...v, userId: this.auth.currentUser?.uid ?? v.userId }))
+      MOCK_VEHICLES.map(v => ({ ...v, userId: this.currentUserId ?? v.userId }))
     );
   }
 

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -17,7 +17,7 @@ export class VehicleService {
 
   public vehicles = signal<VehicleInterface[]>([]);
 
-  private readonly useMock = true;
+  private readonly useMock = false;
 
   private get currentUserId(): string | undefined {
     return this.auth.currentUser?.uid;

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -137,7 +137,7 @@ export class VehicleService {
     const newVehicle = { 
       ...vehicle, 
       _id: crypto.randomUUID(), 
-      userId: this.auth.currentUser?.uid ?? 'mock-user' 
+      userId: this.currentUserId ?? 'mock-user'
     };
     this.vehicles.update(list => [...list, newVehicle]);
   }

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -19,6 +19,11 @@ export class VehicleService {
 
   private readonly useMock = false;
 
+  private get currentUserId(): string | undefined {
+    return this.auth.currentUser?.uid;
+  }
+
+
   loadVehicles(): void {
     if (this.useMock) return this.loadMockVehicles();
 


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/pull/212)

## Summary
Introduce a private `currentUserId` getter in `VehicleService` to centralize access to the authenticated user's ID and remove duplicated `this.auth.currentUser?.uid` references across mock methods.

---

## What's included
- Added a private `currentUserId` getter.
- Updated `loadMockVehicles()` to use `this.currentUserId`.
- Updated `addMockVehicle()` to use `this.currentUserId`.

---

## Notes
- No behavior changes.
- Only mock methods are affected since HTTP methods don't access `currentUser` directly.