### PR TITLE
refactor(vehicle-service): simplify HTTP subscribe callbacks (#213)

### DIFF
--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -66,11 +66,11 @@ export class VehicleService {
     if (this.useMock) return this.updateMockLocation(vehicle, location);
 
     this.http.put<VehicleInterface>(`${this.apiUrl}/${vehicle._id}`, { location })
-      .subscribe(updatedVehicle => {
+      .subscribe(updatedVehicle => 
         this.vehicles.update(list =>
           list.map(v => v._id === vehicle._id ? updatedVehicle : v)
-        );
-      });
+        )
+      );
   }
 
   deleteVehicle(vehicle: VehicleInterface): void {

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -77,9 +77,9 @@ export class VehicleService {
     if (this.useMock) return this.deleteMockVehicle(vehicle);
 
     this.http.delete<void>(`${this.apiUrl}/${vehicle._id}`)
-      .subscribe(() => {
-        this.vehicles.update(list => list.filter(v => v._id !== vehicle._id));
-      });
+      .subscribe(() => 
+        this.vehicles.update(list => list.filter(v => v._id !== vehicle._id))
+      );
   }
 
   addUserToVehicle(vehicleId: string, email: string): Observable<{ userId: string; email: string }> {

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -49,14 +49,14 @@ export class VehicleService {
     if (this.useMock) return this.updateMockVehicle(oldVehicle, newVehicle);
 
     this.http.put<VehicleInterface>(`${this.apiUrl}/${oldVehicle._id}`, newVehicle)
-      .subscribe(updatedVehicle => {
+      .subscribe(updatedVehicle => 
         this.vehicles.update(list =>
           list.map(v => v._id === oldVehicle._id 
             ? updatedVehicle 
             : v
           )
-        );
-      });
+        )
+      );
   }
 
   updateVehicleLocation(

--- a/src/app/features/vehicle/data-access/vehicle-service.ts
+++ b/src/app/features/vehicle/data-access/vehicle-service.ts
@@ -37,9 +37,9 @@ export class VehicleService {
     if (this.useMock) return this.addMockVehicle(vehicle);
 
     this.http.post<VehicleInterface>(this.apiUrl, vehicle)
-      .subscribe(vehicleCreated => {
-        this.vehicles.update(list => [...list, vehicleCreated]);
-      });
+      .subscribe(vehicleCreated => 
+        this.vehicles.update(list => [...list, vehicleCreated])
+      );
   }
 
   updateVehicle(


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/213)

## Summary
Simplify HTTP `subscribe` callbacks in `VehicleService` methods to improve readability by removing unnecessary block syntax while keeping the logic unchanged.

---

## What's included
- Simplified `addVehicle` subscribe callback.
- Simplified `updateVehicle` subscribe callback.
- Simplified `updateVehicleLocation` subscribe callback.
- Simplified `deleteVehicle` subscribe callback.

---

## Notes
- No behavior changes.
- No changes to API calls or state management logic.
- Only refactor of callback syntax for readability.