### PR TITLE
refactor(map): Extract map routing configuration into feature routes (#224)

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -25,8 +25,8 @@ export const routes: Routes = [
       },
       {
         path: 'map',
-        loadComponent: () =>
-          import('./features/map/pages/map/map-page').then(m => m.MapPageComponent)
+        loadChildren: () =>
+          import('./features/map/map.routes').then(m => m.MAP_ROUTES)
       },
       {
         path: 'calendar',

--- a/src/app/features/map/map.routes.ts
+++ b/src/app/features/map/map.routes.ts
@@ -1,3 +1,9 @@
 import { Routes } from '@angular/router';
 
-export const MAP_ROUTES: Routes = [];
+export const MAP_ROUTES: Routes = [
+    {
+        path: '',
+        loadComponent: () =>
+        import('./pages/map/map-page').then(m => m.MapPageComponent)
+    }
+];


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/224)

## Summary

Extract the map routing configuration from `app.routes.ts` into a dedicated `map.routes.ts` file, allowing the map feature to own its routing configuration while preserving the existing navigation behavior.

## What's included

- Added `MAP_ROUTES` configuration inside `features/map/map.routes.ts`.
- Moved the map page route definition from `app.routes.ts` into the map feature routing file.
- Updated `app.routes.ts` to lazy-load map routes using `loadChildren`.
- Removed the direct dependency between the application router and the map page component.
- Maintained the existing `/map` navigation path.
- Preserved authentication guard behavior for the map feature.

## Notes

- No behavior changes.
- Existing map navigation remains unchanged.
- Authentication and authorization flows remain untouched.
- This change only moves routing ownership from the application router to the map feature.
- This follows the new feature-based routing architecture introduced in the previous routing preparation task.