### PR TITLE
refactor(calendar): Extract calendar routing configuration into feature routes (#225)

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -30,8 +30,8 @@ export const routes: Routes = [
       },
       {
         path: 'calendar',
-        loadComponent: () =>
-          import('./features/calendar/pages/calendar/calendar-page').then(m => m.CalendarPageComponent)
+        loadChildren: () =>
+          import('./features/calendar/calendar.routes').then(m => m.CALENDAR_ROUTES)
       },
       {
         path: 'graphics',

--- a/src/app/features/calendar/calendar.routes.ts
+++ b/src/app/features/calendar/calendar.routes.ts
@@ -1,3 +1,9 @@
 import { Routes } from '@angular/router';
 
-export const CALENDAR_ROUTES: Routes = [];
+export const CALENDAR_ROUTES: Routes = [
+    {
+        path: '',
+        loadComponent: () =>
+            import('./pages/calendar/calendar-page').then(m => m.CalendarPageComponent)
+    },
+];


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/225)

## Summary

Extract the calendar routing configuration from `app.routes.ts` into a dedicated `calendar.routes.ts` file, allowing the calendar feature to own its routing configuration while preserving the existing navigation behavior.

## What's included

- Added `CALENDAR_ROUTES` configuration inside `features/calendar/calendar.routes.ts`.
- Moved the calendar page route definition from `app.routes.ts` into the calendar feature routing file.
- Updated `app.routes.ts` to lazy-load calendar routes using `loadChildren`.
- Removed the direct dependency between the application router and the calendar page component.
- Maintained the existing `/calendar` navigation path.
- Preserved authentication guard behavior for the calendar feature.

## Notes

- No behavior changes.
- Existing calendar navigation remains unchanged.
- Authentication and authorization flows remain untouched.
- This change only moves routing ownership from the application router to the calendar feature.
- This follows the new feature-based routing architecture introduced in the previous routing preparation task.