### PR TITLE
refactor(graphics): Extract graphics routing configuration into feature routes (#226)

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -35,8 +35,8 @@ export const routes: Routes = [
       },
       {
         path: 'graphics',
-        loadComponent: () =>
-          import('./features/graphics/pages/graphics/graphics-page').then(m => m.GraphicsPageComponent)
+        loadChildren: () =>
+          import('./features/graphics/graphics.routes').then(m => m.GRAPHICS_ROUTES)
       }
     ]
   },

--- a/src/app/features/graphics/graphics.routes.ts
+++ b/src/app/features/graphics/graphics.routes.ts
@@ -1,3 +1,9 @@
 import { Routes } from '@angular/router';
 
-export const GRAPHICS_ROUTES: Routes = [];
+export const GRAPHICS_ROUTES: Routes = [
+    {
+        path: '',
+        loadComponent: () =>
+            import('./pages/graphics/graphics-page').then(m => m.GraphicsPageComponent)
+    }
+];


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/226)

## Summary

Extract the graphics routing configuration from `app.routes.ts` into a dedicated `graphics.routes.ts` file, allowing the graphics feature to own its routing configuration while preserving the existing navigation behavior.

## What's included

- Added `GRAPHICS_ROUTES` configuration inside `features/graphics/graphics.routes.ts`.
- Moved the graphics page route definition from `app.routes.ts` into the graphics feature routing file.
- Updated `app.routes.ts` to lazy-load graphics routes using `loadChildren`.
- Removed the direct dependency between the application router and the graphics page component.
- Maintained the existing `/graphics` navigation path.
- Preserved authentication guard behavior for the graphics feature.

## Notes

- No behavior changes.
- Existing graphics navigation remains unchanged.
- Authentication and authorization flows remain untouched.
- This change only moves routing ownership from the application router to the graphics feature.
- This follows the new feature-based routing architecture introduced in the previous routing preparation task.