### PR TITLE
refactor(auth): Extract authentication routing configuration into feature routes (#222)

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,22 +1,17 @@
 import { Routes } from '@angular/router';
 import { canActivate, redirectUnauthorizedTo } from '@angular/fire/auth-guard';
 
-const redirectUnauthorizedToLogin = () => redirectUnauthorizedTo(['/login']);
+const redirectUnauthorizedToAuth = () => redirectUnauthorizedTo(['/auth']);
 
 export const routes: Routes = [
   {
-    path: 'register',
-    loadComponent: () =>
-      import('./features/auth/pages/register/register').then(m => m.RegisterPageComponent)
-  },
-  {
-    path: 'login',
-    loadComponent: () =>
-      import('./features/auth/pages/login/login').then(m => m.LoginPageComponent)
+    path: 'auth',
+    loadChildren: () =>
+      import('./features/auth/auth.routes').then(m => m.AUTH_ROUTES)
   },
   {
     path: '',
-    ...canActivate(redirectUnauthorizedToLogin),
+    ...canActivate(redirectUnauthorizedToAuth),
     children: [
       {
         path: '',

--- a/src/app/core/layout/auth-actions/auth-actions.html
+++ b/src/app/core/layout/auth-actions/auth-actions.html
@@ -19,7 +19,7 @@
         <button
             class="navbar__auth-button"
             data-test="registerButton"
-            [routerLink]="['/register']"
+            [routerLink]="['/auth/register']"
             routerLinkActive="active"
             [attr.aria-label]="authActionsMsg.aria.register"
         >
@@ -28,7 +28,7 @@
         <button
             class="navbar__auth-button"
             data-test="loginButton"
-            [routerLink]="['/login']"
+            [routerLink]="['/auth/login']"
             routerLinkActive="active"
             [attr.aria-label]="authActionsMsg.aria.login"
         >

--- a/src/app/core/layout/auth-actions/auth-actions.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.ts
@@ -38,7 +38,7 @@ export class AuthActionsComponent {
 
   onLogout(): void {
     this.auth.logout()
-      .then(() => this.router.navigate(['login']))
+      .then(() => this.router.navigate(['/auth/login']))
       .catch(error => console.error(error));
   }
 }

--- a/src/app/features/auth/auth.routes.ts
+++ b/src/app/features/auth/auth.routes.ts
@@ -1,3 +1,19 @@
 import { Routes } from '@angular/router';
 
-export const AUTH_ROUTES: Routes = [];
+export const AUTH_ROUTES: Routes = [
+    {
+        path: '',
+        redirectTo: 'login',
+        pathMatch: 'full'
+    },
+    {
+        path: 'login',
+        loadComponent: () =>
+            import('./pages/login/login').then(m => m.LoginPageComponent)
+    },
+    {
+        path: 'register',
+        loadComponent: () =>
+            import('./pages/register/register').then(m => m.RegisterPageComponent)
+    },
+];

--- a/src/app/features/auth/pages/login/login.html
+++ b/src/app/features/auth/pages/login/login.html
@@ -80,7 +80,7 @@
     {{ formMsg.switch.toRegister.prompt }}
     <a 
       class="auth__link"
-      routerLink="/register"
+      routerLink="/auth/register"
       [attr.aria-label]="formMsg.aria.switch.toRegister"
     >
       {{ formMsg.switch.toRegister.action }}

--- a/src/app/features/auth/pages/register/register.html
+++ b/src/app/features/auth/pages/register/register.html
@@ -88,7 +88,7 @@
     {{ formMsg.switch.toLogin.prompt }}
     <a
       class="auth__link"
-      routerLink="/login"
+      routerLink="/auth/login"
       [attr.aria-label]="formMsg.aria.switch.toLogin"
     >
       {{ formMsg.switch.toLogin.action }}

--- a/src/app/features/map/map.routes.ts
+++ b/src/app/features/map/map.routes.ts
@@ -4,6 +4,6 @@ export const MAP_ROUTES: Routes = [
     {
         path: '',
         loadComponent: () =>
-        import('./pages/map/map-page').then(m => m.MapPageComponent)
+            import('./pages/map/map-page').then(m => m.MapPageComponent)
     }
 ];


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/222)

## Summary

Move the authentication routing configuration into a dedicated `auth.routes.ts` file, allowing the authentication feature to own its routing configuration while updating authentication navigation to use the new feature-based routes.

## What's included

- Added `AUTH_ROUTES` configuration inside `features/auth/auth.routes.ts`.
- Moved login and register route definitions from `app.routes.ts` into the authentication feature routing file.
- Updated `app.routes.ts` to lazy-load authentication routes using `loadChildren`.
- Added the authentication route prefix using `/auth`.
- Updated authentication navigation links to use the new `/auth/login` and `/auth/register` paths.
- Updated logout navigation to redirect to `/auth/login`.
- Updated login and register page navigation links to reference the new authentication routes.

## Notes

- No authentication behavior changes.
- Login and register functionality remains unchanged.
- Authentication guard behavior remains preserved.
- Form validation and authentication flows remain untouched.
- This change only moves routing ownership from the application router to the authentication feature.
- This follows the feature-based routing architecture used by the rest of the application features.