### PR TITLE
docs(readme): Remove outdated GitHub Pages section (#232)

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,12 +445,6 @@ If you want to contribute to this project, you can:
 
 ---
 
-## GitHub Pages
-
-> The application is currently not deployed on GitHub Pages.
-
----
-
 ## Author
 
 [**Jordi Miravet**](https://www.linkedin.com/in/jordimiravet-dev/)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@
 - [Project Preview](#project-preview)
 - [Tests](#tests)
 - [Contribution](#contribution)
-- [GitHub Pages](#github-pages)
 - [Author](#author)
 
 ---


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/232)

## Summary

Remove the outdated GitHub Pages section from the README, as the project does not currently provide a public deployment.
The table of contents has also been updated to keep the documentation navigation consistent.

## What's included

- Removed the GitHub Pages section from the README.
- Removed the corresponding entry from the table of contents.
- Updated the README navigation to reflect the current documentation structure.

## Notes

- No application behavior has changed.
- A deployment section can be added again in the future once a public demo environment is available.