### PR TITLE
feat(map): Add vehicle image markers (#252)

### DIFF
--- a/src/app/features/map/components/map-view/map-view.scss
+++ b/src/app/features/map/components/map-view/map-view.scss
@@ -72,18 +72,25 @@
 }
 
 ::ng-deep .vehicle-marker {
-    width: 48px;
-    height: 48px;
+    width: 7.5rem;
+    height: 7.5rem;
 
     background: transparent;
     border: none;
 
     img {
-        width: 48px;
-        height: 48px;
+        display: block;
+
+        width: 7.5rem;
+        height: 7.5rem;
+
         object-fit: cover;
+
+        aspect-ratio: 1 / 1;
+
         border-radius: 50%;
         border: 3px solid white;
+
         box-shadow: 0 2px 8px rgba(0, 0, 0, .35);
     }
 }

--- a/src/app/features/map/components/map-view/map-view.scss
+++ b/src/app/features/map/components/map-view/map-view.scss
@@ -70,3 +70,20 @@
         }
     }
 }
+
+::ng-deep .vehicle-marker {
+    width: 48px;
+    height: 48px;
+
+    background: transparent;
+    border: none;
+
+    img {
+        width: 48px;
+        height: 48px;
+        object-fit: cover;
+        border-radius: 50%;
+        border: 3px solid white;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, .35);
+    }
+}

--- a/src/app/features/map/components/map-view/map-view.ts
+++ b/src/app/features/map/components/map-view/map-view.ts
@@ -73,7 +73,7 @@ export class MapViewComponent implements OnInit, OnDestroy {
       if (!vehicle.location) return;
 
       const coords: [number, number] = [vehicle.location.lat, vehicle.location.lng];
-      const marker = this.mapService.createMarker(coords, false);
+      const marker = this.mapService.createMarker(coords, vehicle, false);
 
       this.allVehicleMarkers.push(marker);
       bounds.extend(coords);
@@ -122,7 +122,11 @@ export class MapViewComponent implements OnInit, OnDestroy {
 
   private placeSelectedVehicleMarker(coords: [number, number] | L.LatLng, vehicleName: string): void {
     this.clearSelectedMarker();
-    this.selectedVehicleMarker = this.mapService.createMarker(coords, true);
+    this.selectedVehicleMarker = this.mapService.createMarker(
+      coords,
+      this.selectedVehicle() ?? undefined,
+      true
+    );
 
     this.selectedVehicleMarker.on('dragend', () => {
       const position = this.selectedVehicleMarker!.getLatLng();

--- a/src/app/features/map/data-access/map-service.ts
+++ b/src/app/features/map/data-access/map-service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import * as L from 'leaflet';
+import { VehicleInterface } from '../../vehicle/interfaces/vehicle/vehicle';
 
 @Injectable({
   providedIn: 'root',
@@ -37,8 +38,23 @@ export class MapService {
     return this.map;
   }
   
+  private createVehicleIcon(vehicle: VehicleInterface): L.DivIcon {
+    return L.divIcon({
+      className: 'vehicle-marker',
+      html: `
+        <img 
+          src="${vehicle.imageUrl}" 
+          alt="${vehicle.name}"
+        />
+      `,
+      iconSize: [48, 48],
+      iconAnchor: [24, 24],
+    });
+  }
+
   createMarker(
     coords: L.LatLngExpression,
+    vehicle?: VehicleInterface,
     draggable: boolean = true
   ): L.Marker {
     const marker = L.marker(coords, {

--- a/src/app/features/map/data-access/map-service.ts
+++ b/src/app/features/map/data-access/map-service.ts
@@ -49,7 +49,7 @@ export class MapService {
           alt="${vehicle.name}"
         />
       `,
-      iconSize: [48, 48],
+      iconSize: [75, 75],
       iconAnchor: [24, 24],
     });
   }

--- a/src/app/features/map/data-access/map-service.ts
+++ b/src/app/features/map/data-access/map-service.ts
@@ -59,7 +59,9 @@ export class MapService {
   ): L.Marker {
     const marker = L.marker(coords, {
       draggable: draggable,
-      icon: this.locationIcon,
+      icon: vehicle
+        ? this.createVehicleIcon(vehicle)
+        : this.locationIcon,
     }).addTo(this.map);
 
     return marker;

--- a/src/app/features/map/data-access/map-service.ts
+++ b/src/app/features/map/data-access/map-service.ts
@@ -39,11 +39,13 @@ export class MapService {
   }
   
   private createVehicleIcon(vehicle: VehicleInterface): L.DivIcon {
+    const fallbackImage = `https://placehold.co/48x48?text=vehicle`;
+
     return L.divIcon({
       className: 'vehicle-marker',
       html: `
         <img 
-          src="${vehicle.imageUrl}" 
+          src="${vehicle.imageUrl || fallbackImage}" 
           alt="${vehicle.name}"
         />
       `,


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/252)

## Summary

Replace the default Leaflet marker icon used for vehicles with a custom marker that displays the vehicle image.

The map now uses vehicle-specific markers with a fallback image when no vehicle image is available, improving the visual identification of vehicles on the map.

## What's included

- Added a custom Leaflet `DivIcon` for vehicle markers.
- Updated `MapService.createMarker()` to support vehicle data when creating markers.
- Added fallback handling for vehicles without an image.
- Applied the new marker style to both the all vehicles view and selected vehicle view.
- Preserved existing marker dragging behavior for location updates.

## Notes

- No backend changes were required.
- No changes were made to vehicle data structure.
- Further marker improvements, such as extracting marker logic into a dedicated component, will be handled in future tasks.