### PR TITLE
feat(map): Update tests for vehicle marker changes (#260)

### DIFF
--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -432,21 +432,14 @@ describe('MapViewComponent', () => {
       spyOn(mapService, 'createMarker').and.returnValue(mockMarker);
       const setViewSpy = spyOn(mapService, 'setView');
 
-      const vehicle = {
-        _id: 'veh-123',
-        name: 'Ferrari',
-        model: 'F8',
-        plate: 'F123',
-        location: { lat: 41, lng: 2 }
-      } as VehicleInterface;
-
-      (component as any).placeSelectedVehicleMarker([41, 2], vehicle);
+      (component as any).placeSelectedVehicleMarker([41, 2], 'Ferrari');
 
       expect(mapService.createMarker).toHaveBeenCalledWith(
         [41, 2],
-        vehicle,
+        undefined,
         true
       );
+
       expect(mockMarker.on).toHaveBeenCalledWith('dragend', jasmine.any(Function));
       expect(setViewSpy).toHaveBeenCalledOnceWith([41, 2], 19);
     });

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -423,7 +423,7 @@ describe('MapViewComponent', () => {
       (component as any).clearAllMarkers();
 
       expect(removeLayerSpy).toHaveBeenCalledTimes(markers.length);
-      expect((component as any).allVehicleMarkers.length).toBe(0);
+      expect((component as any).allVehicleMarkers).toHaveSize(0);
     });
 
     it('should place selected vehicle marker', () => {

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -144,7 +144,12 @@ describe('MapViewComponent', () => {
 
       component.showVehicle(selectedVehicleMock);
 
-      expect(mapService.createMarker).toHaveBeenCalledWith([41, 2], true);
+      expect(mapService.createMarker).toHaveBeenCalledWith(
+        [41, 2],
+        selectedVehicleMock,
+        true
+      );
+
       expect(mockMarker.on).toHaveBeenCalledWith('dragend', jasmine.any(Function));
     });
 

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -432,9 +432,21 @@ describe('MapViewComponent', () => {
       spyOn(mapService, 'createMarker').and.returnValue(mockMarker);
       const setViewSpy = spyOn(mapService, 'setView');
 
-      (component as any).placeSelectedVehicleMarker([41, 2], 'Ferrari');
+      const vehicle = {
+        _id: 'veh-123',
+        name: 'Ferrari',
+        model: 'F8',
+        plate: 'F123',
+        location: { lat: 41, lng: 2 }
+      } as VehicleInterface;
 
-      expect(mapService.createMarker).toHaveBeenCalledWith([41, 2], true);
+      (component as any).placeSelectedVehicleMarker([41, 2], vehicle);
+
+      expect(mapService.createMarker).toHaveBeenCalledWith(
+        [41, 2],
+        vehicle,
+        true
+      );
       expect(mockMarker.on).toHaveBeenCalledWith('dragend', jasmine.any(Function));
       expect(setViewSpy).toHaveBeenCalledOnceWith([41, 2], 19);
     });

--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -105,11 +105,15 @@ describe('MapService', () => {
       expect(marker.dragging?.enabled()).toBeTrue();
     });
 
-    it('should create a marker with draggable set to true', () => {
-      const marker = service.createMarker([41.3851, 2.1734], true);
+  it('should create a marker with draggable set to true', () => {
+    const marker = service.createMarker(
+      [41.3851, 2.1734],
+      mockVehicle,
+      true
+    );
 
-      expect(marker.dragging?.enabled()).toBeTrue();
-    });
+    expect(marker.dragging?.enabled()).toBeTrue();
+  });
 
     it('should create a marker with draggable set to false', () => {
       const marker = service.createMarker([41.3851, 2.1734], false);

--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -54,7 +54,7 @@ describe('MapService', () => {
       const map = service.initMap('map', [41.3851, 2.1734], 13);
       const tileLayers = Object.values((map as any)._layers).filter(layer => layer instanceof L.TileLayer);
 
-      expect(tileLayers.length).toBe(1);
+      expect(tileLayers).toHaveSize(1);
     });
 
     it('should return the created map', () => {

--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -105,15 +105,15 @@ describe('MapService', () => {
       expect(marker.dragging?.enabled()).toBeTrue();
     });
 
-  it('should create a marker with draggable set to true', () => {
-    const marker = service.createMarker(
-      [41.3851, 2.1734],
-      mockVehicle,
-      true
-    );
+    it('should create a marker with draggable set to true', () => {
+      const marker = service.createMarker(
+        [41.3851, 2.1734],
+        mockVehicle,
+        true
+      );
 
-    expect(marker.dragging?.enabled()).toBeTrue();
-  });
+      expect(marker.dragging?.enabled()).toBeTrue();
+    });
 
     it('should create a marker with draggable set to false', () => {
       const marker = service.createMarker(

--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -116,7 +116,11 @@ describe('MapService', () => {
   });
 
     it('should create a marker with draggable set to false', () => {
-      const marker = service.createMarker([41.3851, 2.1734], false);
+      const marker = service.createMarker(
+        [41.3851, 2.1734],
+        mockVehicle,
+        false
+      );
 
       expect(marker.dragging?.enabled()).toBeFalse();
     });

--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -2,12 +2,20 @@ import { TestBed } from '@angular/core/testing';
 import * as L from 'leaflet';
 
 import { MapService } from './map-service';
+import { VehicleInterface } from '../../vehicle/interfaces/vehicle/vehicle';
 
 function createMapDom() {
   const div = document.createElement('div');
   div.id = 'map';
   document.body.appendChild(div);
 }
+
+const mockVehicle: VehicleInterface = {
+  name: 'Ferrari LaFerrari',
+  model: 'LaFerrari',
+  plate: 'F1234ABC',
+  imageUrl: 'https://example.com/ferrari-laferrari.png',
+};
 
 describe('MapService', () => {
   let service: MapService;


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/260)

## Summary

Update existing map unit tests to match the new vehicle marker implementation and the updated marker creation flow.

The tests now validate the new `createMarker()` signature that supports vehicle data while keeping existing map behavior and marker interactions covered.

## What's included

- Updated `MapService` tests to support vehicle-based marker creation.
- Updated `MapViewComponent` tests after adding vehicle data to marker creation.
- Updated marker expectations for selected vehicle markers.
- Improved existing test assertions for better readability.
- Kept draggable marker behavior covered.
- Ensured map-related unit tests continue validating current functionality.

## Notes

- Unit tests only.
- No application behavior changes were introduced.
- No backend changes were required.
- Authentication and unrelated component tests are not included in this task.