### PR TITLE
feat(map): Extract vehicle marker into a dedicated component and improve marker management (#259)

### DIFF
--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -23,7 +23,9 @@ export const authMock = {
 
 const vehicleMarkerManagerMock = {
   mountComponent: jasmine.createSpy('mountComponent')
-    .and.returnValue(() => {})
+    .and.returnValue(() => {}),
+  createIcon: jasmine.createSpy('createIcon')
+    .and.returnValue(L.divIcon())
 };
 
 const mockVehicle1: VehicleInterface = {
@@ -436,17 +438,14 @@ describe('MapViewComponent', () => {
     it('should place selected vehicle marker', () => {
       const mapService = TestBed.inject(MapService);
       const mockMarker: any = { on: jasmine.createSpy('on') };
+
       spyOn(mapService, 'createMarker').and.returnValue(mockMarker);
       const setViewSpy = spyOn(mapService, 'setView');
 
-      (component as any).placeSelectedVehicleMarker([41, 2], 'Ferrari');
+      component.selectedVehicle.set(mockVehicle1);
+      (component as any).placeSelectedVehicleMarker([41, 2]);
 
-      expect(mapService.createMarker).toHaveBeenCalledWith(
-        [41, 2],
-        undefined,
-        true
-      );
-
+      expect(mapService.createMarker).toHaveBeenCalledWith([41, 2], mockVehicle1, true);
       expect(mockMarker.on).toHaveBeenCalledWith('dragend', jasmine.any(Function));
       expect(setViewSpy).toHaveBeenCalledOnceWith([41, 2], 19);
     });

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -12,12 +12,18 @@ import { MapService } from '../../data-access/map-service';
 import { GeolocationService } from '../../../../core/services/geolocation/geolocation-service';
 import { VehicleService } from '../../../vehicle/data-access/vehicle-service';
 import { VehicleInterface } from '../../../vehicle/interfaces/vehicle/vehicle';
+import { VehicleMarkerManager } from '../../data-access/vehicle-marker-manager';
 
 export const authMock = {
   currentUser: {
     uid: 'JordiTheBest',
     getIdToken: () => Promise.resolve('MyToken')
   }
+};
+
+const vehicleMarkerManagerMock = {
+  mountComponent: jasmine.createSpy('mountComponent')
+    .and.returnValue(() => {})
 };
 
 const mockVehicle1: VehicleInterface = {
@@ -64,6 +70,7 @@ describe('MapViewComponent', () => {
       providers: [
         { provide: Auth, useValue: authMock },
         { provide: VehicleService, useValue: vehicleServiceMock },
+        { provide: VehicleMarkerManager, useValue: vehicleMarkerManagerMock },
         provideHttpClient(),
         provideHttpClientTesting(),
       ]

--- a/src/app/features/map/components/vehicle-marker/vehicle-marker.spec.ts
+++ b/src/app/features/map/components/vehicle-marker/vehicle-marker.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { VehicleMarkerComponent } from './vehicle-marker';
 
 describe('VehicleMarkerComponent', () => {
@@ -14,6 +13,14 @@ describe('VehicleMarkerComponent', () => {
 
     fixture = TestBed.createComponent(VehicleMarkerComponent);
     component = fixture.componentInstance;
+
+    fixture.componentRef.setInput('vehicle', {
+      name: 'Ferrari',
+      model: 'LaFerrari',
+      plate: '1234ABC',
+      imageUrl: 'test-image.jpg'
+    });
+
     fixture.detectChanges();
   });
 

--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -229,26 +229,4 @@ describe('MapService', () => {
 
   });
 
-  describe('locationIcon', () => {
-
-    it('should initialize the location icon', () => {
-      expect(service.locationIcon).toBeTruthy();
-    });
-
-    it('should configure the icon urls', () => {
-      expect(service.locationIcon.options.iconUrl).toBe('/assets/icons/marker-icon.png');
-      expect(service.locationIcon.options.iconRetinaUrl).toBe('/assets/icons/marker-icon-2x.png');
-      expect(service.locationIcon.options.shadowUrl).toBe('/assets/icons/marker-shadow.png');
-    });
-
-    it('should configure the icon size', () => {
-      expect(service.locationIcon.options.iconSize).toEqual([25, 40]);
-    });
-
-    it('should configure the shadow anchor', () => {
-      expect(service.locationIcon.options.shadowAnchor).toEqual([9, 19]);
-    });
-
-  });
-
 });

--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -125,10 +125,10 @@ describe('MapService', () => {
       expect(marker.dragging?.enabled()).toBeFalse();
     });
 
-    it('should use the configured location icon', () => {
+    it('should create a marker with a Leaflet icon when no vehicle is provided', () => {
       const marker = service.createMarker([41.3851, 2.1734]);
 
-      expect((marker.options as any).icon).toBe(service.locationIcon);
+      expect((marker.options as any).icon).toEqual(jasmine.any(L.Icon));
     });
 
     it('should add the marker to the map', () => {


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/259)

## Summary
Update the existing map-related unit tests to restore compatibility with the recent vehicle marker implementation changes.
The introduction of custom vehicle markers and the extraction of marker rendering into a dedicated component affected several existing tests. This PR adapts those tests to the new implementation while preserving the existing coverage.

## What's included
- Removed obsolete location icon unit tests that no longer apply after the vehicle marker refactoring.
- Updated marker icon assertions in `map-service.spec.ts` to match the new icon creation flow.
- Provided the required `vehicle` input in `VehicleMarkerComponent` tests, which is now mandatory after the component extraction.
- Added a mock `VehicleMarkerManager` dependency to `map-view.spec.ts`.
- Fixed `createIcon` mock returning `undefined` in `map-view.spec.ts`, which was breaking Leaflet marker creation during tests.

## Notes
- This PR only fixes existing unit tests affected by the previous vehicle marker refactoring (#256).
- No new test scenarios were introduced.
- No production code behavior was modified.
- No backend or vehicle data changes were required.