### PR TITLE
test(map-view): Update MapViewComponent unit tests after vehicle marker refactoring (#270)

### DIFF
--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -67,6 +67,9 @@ describe('MapViewComponent', () => {
       updateVehicleLocation: jasmine.createSpy('updateVehicleLocation')
     };
 
+    vehicleMarkerManagerMock.mountComponent.calls.reset();
+    vehicleMarkerManagerMock.createIcon.calls.reset();
+
     await TestBed.configureTestingModule({
       imports: [MapViewComponent],
       providers: [
@@ -120,17 +123,9 @@ describe('MapViewComponent', () => {
 
   describe('vehicle selection', () => {
 
-    const selectedVehicleMock: VehicleInterface = {
-      _id: 'veh-123',
-      name: 'Ferrari',
-      model: 'F8',
-      plate: 'F123',
-      location: { lat: 41, lng: 2 }
-    };
-
     it('should set selectedVehicle when showVehicle is called', () => {
-      component.showVehicle(selectedVehicleMock);
-      expect(component.selectedVehicle()).toBe(selectedVehicleMock);
+      component.showVehicle(mockVehicle1);
+      expect(component.selectedVehicle()).toBe(mockVehicle1);
     });
 
     it('should remove previous vehicle marker if it exists', () => {
@@ -140,7 +135,7 @@ describe('MapViewComponent', () => {
       (component as any).selectedVehicleMarker = mockMarker;
       const removeLayerSpy = spyOn(mapService, 'removeLayer');
 
-      component.showVehicle(selectedVehicleMock);
+      component.showVehicle(mockVehicle1);
 
       expect(removeLayerSpy).toHaveBeenCalledOnceWith(mockMarker);
     });
@@ -151,11 +146,11 @@ describe('MapViewComponent', () => {
 
       spyOn(mapService, 'createMarker').and.returnValue(mockMarker);
 
-      component.showVehicle(selectedVehicleMock);
+      component.showVehicle(mockVehicle1);
 
       expect(mapService.createMarker).toHaveBeenCalledWith(
         [41, 2],
-        selectedVehicleMock,
+        mockVehicle1,
         true
       );
 
@@ -166,7 +161,7 @@ describe('MapViewComponent', () => {
       const mapService = TestBed.inject(MapService);
       const setViewSpy = spyOn(mapService, 'setView');
 
-      component.showVehicle(selectedVehicleMock);
+      component.showVehicle(mockVehicle1);
 
       expect(setViewSpy).toHaveBeenCalledOnceWith([41, 2], 19);
     });
@@ -238,13 +233,6 @@ describe('MapViewComponent', () => {
 
   describe('confirm location change', () => {
 
-    const selectedVehicleMock: VehicleInterface = {
-      name: 'Ferrari',
-      model: 'F8',
-      plate: 'F123',
-      location: { lat: 41, lng: 2 }
-    };
-
     it('should not update if there is no selected vehicle', () => {
       component.selectedVehicle.set(null);
       component.onConfirmLocationChange();
@@ -253,7 +241,7 @@ describe('MapViewComponent', () => {
     });
 
     it('should not update if there is no new position', () => {
-      component.selectedVehicle.set(selectedVehicleMock);
+      component.selectedVehicle.set(mockVehicle1);
       component.newPosition.set(null);
       component.onConfirmLocationChange();
 
@@ -263,7 +251,7 @@ describe('MapViewComponent', () => {
     it('should update vehicle location when confirmed', () => {
       const newPos = { lat: 50, lng: 8 } as any;
 
-      component.selectedVehicle.set(selectedVehicleMock);
+      component.selectedVehicle.set(mockVehicle1);
       component.newPosition.set(newPos);
       component.onConfirmLocationChange();
 
@@ -273,7 +261,7 @@ describe('MapViewComponent', () => {
     it('should update selectedVehicle with the new location', () => {
       const newPos = { lat: 50, lng: 8 } as any;
 
-      component.selectedVehicle.set(selectedVehicleMock);
+      component.selectedVehicle.set(mockVehicle1);
       component.newPosition.set(newPos);
 
       component.onConfirmLocationChange();
@@ -284,7 +272,7 @@ describe('MapViewComponent', () => {
     it('should hide confirmation modal after confirming', () => {
       const newPos = { lat: 50, lng: 8 } as any;
 
-      component.selectedVehicle.set(selectedVehicleMock);
+      component.selectedVehicle.set(mockVehicle1);
       component.newPosition.set(newPos);
       component.showConfirmModal.set(true);
 
@@ -299,7 +287,7 @@ describe('MapViewComponent', () => {
 
       const newPos = { lat: 50, lng: 8 } as any;
 
-      component.selectedVehicle.set(selectedVehicleMock);
+      component.selectedVehicle.set(mockVehicle1);
       component.newPosition.set(newPos);
 
       component.onConfirmLocationChange();
@@ -311,18 +299,10 @@ describe('MapViewComponent', () => {
 
   describe('cancel location change', () => {
 
-    const selectedVehicleMock: VehicleInterface = {
-      _id: '123',
-      name: 'Ferrari',
-      model: 'F8',
-      plate: 'F123',
-      location: { lat: 41, lng: 2 }
-    };
-
     it('should reset marker position to original vehicle location', () => {
       const mockMarker: any = { setLatLng: jasmine.createSpy('setLatLng') };
 
-      component.selectedVehicle.set(selectedVehicleMock);
+      component.selectedVehicle.set(mockVehicle1);
       (component as any).selectedVehicleMarker = mockMarker;
 
       component.onCancelLocationChange();
@@ -333,7 +313,7 @@ describe('MapViewComponent', () => {
     it('should hide confirmation modal after cancelling', () => {
       const mockMarker: any = { setLatLng: jasmine.createSpy('setLatLng') };
 
-      component.selectedVehicle.set(selectedVehicleMock);
+      component.selectedVehicle.set(mockVehicle1);
       (component as any).selectedVehicleMarker = mockMarker;
       component.showConfirmModal.set(true);
 
@@ -349,7 +329,7 @@ describe('MapViewComponent', () => {
     });
 
     it('should do nothing when there is no marker', () => {
-      component.selectedVehicle.set(selectedVehicleMock);
+      component.selectedVehicle.set(mockVehicle1);
       (component as any).selectedVehicleMarker = undefined;
 
       expect(() => component.onCancelLocationChange()).not.toThrow();
@@ -358,14 +338,6 @@ describe('MapViewComponent', () => {
   });
 
   describe('user location', () => {
-
-    const selectedVehicleMock: VehicleInterface = {
-      _id: '123',
-      name: 'Ferrari',
-      model: 'F8',
-      plate: 'F123',
-      location: { lat: 41, lng: 2 }
-    };
 
     it('should not request geolocation if no vehicle selected', async () => {
       const geo = TestBed.inject(GeolocationService);
@@ -381,7 +353,7 @@ describe('MapViewComponent', () => {
       const geo = TestBed.inject(GeolocationService);
       spyOn(geo, 'getCurrentLocation').and.returnValue(Promise.resolve([50, 8]));
 
-      component.selectedVehicle.set(selectedVehicleMock);
+      component.selectedVehicle.set(mockVehicle1);
 
       await component.onUserLocationClick();
 
@@ -398,7 +370,7 @@ describe('MapViewComponent', () => {
       } as any);
       spyOn(mapService, 'setView');
 
-      component.selectedVehicle.set(selectedVehicleMock);
+      component.selectedVehicle.set(mockVehicle1);
 
       await component.onUserLocationClick();
 
@@ -412,7 +384,7 @@ describe('MapViewComponent', () => {
       spyOn(geo, 'getCurrentLocation').and.returnValue(Promise.reject('error'));
       spyOn(console, 'error');
 
-      component.selectedVehicle.set(selectedVehicleMock);
+      component.selectedVehicle.set(mockVehicle1);
 
       await component.onUserLocationClick();
 
@@ -479,14 +451,7 @@ describe('MapViewComponent', () => {
     });
 
     it('should render user location button when vehicle is selected', () => {
-      component.selectedVehicle.set({
-        _id: '123',
-        name: 'Ferrari',
-        model: 'F8',
-        plate: 'F123',
-        location: { lat: 41, lng: 2 }
-      });
-  
+      component.selectedVehicle.set(mockVehicle1);
       fixture.detectChanges();
 
       const userLocationButtonComponent = fixture.nativeElement.querySelector('app-details-panel');

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -31,24 +31,24 @@ const vehicleMarkerManagerMock = {
 const mockVehicle1: VehicleInterface = {
   _id: 'veh-123',
   name: 'Ferrari',
-  model: 'F8',
+  model: 'Laferrari',
   plate: 'F123',
   location: { lat: 41, lng: 2 }
 };
 
 const mockVehicle2: VehicleInterface = {
-  _id: 'veh-999',
-  name: 'Porsche',
-  model: '911',
-  plate: 'BBB',
+  _id: 'veh-456',
+  name: 'Koenigsegg',
+  model: 'Regera',
+  plate: 'R123',
   location: { lat: 42, lng: 3 }
 };
 
 const mockVehicleWithoutLocation: VehicleInterface = {
-  _id: 'veh-456',
-  name: 'Ferrari',
-  model: 'LaFerrari',
-  plate: '123456',
+  _id: 'veh-789',
+  name: 'Pagani',
+  model: 'Huayra',
+  plate: 'P123',
   location: undefined
 };
 

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -504,4 +504,16 @@ describe('MapViewComponent', () => {
 
   });
 
+  describe('marker mounting', () => {
+
+    it('should call mountComponent for each vehicle when showing all vehicles');
+
+    it('should store cleanup function in markerCleanups for each vehicle marker');
+
+    it('should call mountComponent for selected vehicle marker');
+
+    it('should store cleanup function in selectedMarkerCleanup');
+
+  });
+
 });

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -568,13 +568,65 @@ describe('MapViewComponent', () => {
 
   describe('marker cleanup', () => {
 
-    it('should invoke cleanup functions from markerCleanups when clearing all markers');
+    it('should invoke cleanup functions from markerCleanups when clearing all markers', () => {
+      const mapService = TestBed.inject(MapService);
+      spyOn(mapService, 'removeLayer');
 
-    it('should remove cleanup from markerCleanups after invoking it');
+      const cleanupFn = jasmine.createSpy('cleanup');
+      const mockMarker = {} as L.Marker;
 
-    it('should invoke selectedMarkerCleanup when clearing selected marker');
+      (component as any).allVehicleMarkers = [mockMarker];
+      (component as any).markerCleanups.set(mockMarker, cleanupFn);
 
-    it('should reset selectedMarkerCleanup to undefined after clearing');
+      (component as any).clearAllMarkers();
+
+      expect(cleanupFn).toHaveBeenCalled();
+    });
+
+    it('should remove cleanup from markerCleanups after invoking it', () => {
+      const mapService = TestBed.inject(MapService);
+      spyOn(mapService, 'removeLayer');
+
+      const cleanupFn = jasmine.createSpy('cleanup');
+      const mockMarker = {} as L.Marker;
+
+      (component as any).allVehicleMarkers = [mockMarker];
+      (component as any).markerCleanups.set(mockMarker, cleanupFn);
+
+      (component as any).clearAllMarkers();
+
+      expect((component as any).markerCleanups.has(mockMarker)).toBeFalse();
+    });
+
+    it('should invoke selectedMarkerCleanup when clearing selected marker', () => {
+      const mapService = TestBed.inject(MapService);
+      spyOn(mapService, 'removeLayer');
+
+      const cleanupFn = jasmine.createSpy('cleanup');
+      const mockMarker = {} as L.Marker;
+
+      (component as any).selectedVehicleMarker = mockMarker;
+      (component as any).selectedMarkerCleanup = cleanupFn;
+
+      (component as any).clearSelectedMarker();
+
+      expect(cleanupFn).toHaveBeenCalled();
+    });
+
+    it('should reset selectedMarkerCleanup to undefined after clearing', () => {
+      const mapService = TestBed.inject(MapService);
+      spyOn(mapService, 'removeLayer');
+
+      const cleanupFn = jasmine.createSpy('cleanup');
+      const mockMarker = {} as L.Marker;
+
+      (component as any).selectedVehicleMarker = mockMarker;
+      (component as any).selectedMarkerCleanup = cleanupFn;
+
+      (component as any).clearSelectedMarker();
+
+      expect((component as any).selectedMarkerCleanup).toBeUndefined();
+    });
 
   });
 

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -506,13 +506,63 @@ describe('MapViewComponent', () => {
 
   describe('marker mounting', () => {
 
-    it('should call mountComponent for each vehicle when showing all vehicles');
+    it('should call mountComponent for each vehicle when showing all vehicles', () => {
+      const mapService = TestBed.inject(MapService);
+      const mockMarker: any = { on: jasmine.createSpy('on') };
 
-    it('should store cleanup function in markerCleanups for each vehicle marker');
+      spyOn(mapService, 'createMarker').and.returnValue(mockMarker);
+      vehicleMarkerManagerMock.mountComponent.calls.reset();
 
-    it('should call mountComponent for selected vehicle marker');
+      vehicleService.vehicles.set([mockVehicle1, mockVehicle2]);
+      (component as any).showAllVehicles();
 
-    it('should store cleanup function in selectedMarkerCleanup');
+      expect(vehicleMarkerManagerMock.mountComponent).toHaveBeenCalledTimes(2);
+    });
+
+    it('should store cleanup function in markerCleanups for each vehicle marker', () => {
+      const mapService = TestBed.inject(MapService);
+      const mockMarker: any = { on: jasmine.createSpy('on') };
+      const cleanupFn = jasmine.createSpy('cleanup');
+
+      spyOn(mapService, 'createMarker').and.returnValue(mockMarker);
+      vehicleMarkerManagerMock.mountComponent.and.returnValue(cleanupFn);
+
+      vehicleService.vehicles.set([mockVehicle1]);
+      (component as any).showAllVehicles();
+
+      expect((component as any).markerCleanups.get(mockMarker)).toBe(cleanupFn);
+    });
+
+    it('should call mountComponent for selected vehicle marker', () => {
+      const mapService = TestBed.inject(MapService);
+      const mockMarker: any = { on: jasmine.createSpy('on') };
+
+      spyOn(mapService, 'createMarker').and.returnValue(mockMarker);
+      vehicleMarkerManagerMock.mountComponent.calls.reset();
+
+      component.selectedVehicle.set(mockVehicle1);
+      (component as any).placeSelectedVehicleMarker([41, 2]);
+
+      expect(vehicleMarkerManagerMock.mountComponent).toHaveBeenCalledWith(
+        mockMarker,
+        mockVehicle1,
+        jasmine.any(Object)
+      );
+    });
+
+    it('should store cleanup function in selectedMarkerCleanup', () => {
+      const mapService = TestBed.inject(MapService);
+      const mockMarker: any = { on: jasmine.createSpy('on') };
+      const cleanupFn = jasmine.createSpy('cleanup');
+
+      spyOn(mapService, 'createMarker').and.returnValue(mockMarker);
+      vehicleMarkerManagerMock.mountComponent.and.returnValue(cleanupFn);
+
+      component.selectedVehicle.set(mockVehicle1);
+      (component as any).placeSelectedVehicleMarker([41, 2]);
+
+      expect((component as any).selectedMarkerCleanup).toBe(cleanupFn);
+    });
 
   });
 

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -438,37 +438,6 @@ describe('MapViewComponent', () => {
 
   });
 
-  describe('template integration', () => {
-
-    it('should render the map container', () => {
-      const mapContainer = fixture.nativeElement.querySelector('#map');
-      expect(mapContainer).toBeTruthy();
-    });
-
-    it('should render vehicle selector component', () => {
-      const vehicleSelectorComponent = fixture.nativeElement.querySelector('app-vehicle-selector');
-      expect(vehicleSelectorComponent).toBeTruthy();
-    });
-
-    it('should render user location button when vehicle is selected', () => {
-      component.selectedVehicle.set(mockVehicle1);
-      fixture.detectChanges();
-
-      const userLocationButtonComponent = fixture.nativeElement.querySelector('app-details-panel');
-      expect(userLocationButtonComponent).toBeTruthy();
-    });
-
-    it('should show confirm modal when showConfirmModal is true', () => {
-      component.showConfirmModal.set(true);
-      fixture.detectChanges();
-
-      const confirmModalComponent = fixture.nativeElement.querySelector('app-confirm-modal');
-
-      expect(confirmModalComponent).toBeTruthy();
-    });
-
-  });
-
   describe('marker mounting', () => {
 
     it('should call mountComponent for each vehicle when showing all vehicles', () => {
@@ -595,4 +564,37 @@ describe('MapViewComponent', () => {
 
   });
 
+
+  describe('template integration', () => {
+
+    it('should render the map container', () => {
+      const mapContainer = fixture.nativeElement.querySelector('#map');
+      expect(mapContainer).toBeTruthy();
+    });
+
+    it('should render vehicle selector component', () => {
+      const vehicleSelectorComponent = fixture.nativeElement.querySelector('app-vehicle-selector');
+      expect(vehicleSelectorComponent).toBeTruthy();
+    });
+
+    it('should render user location button when vehicle is selected', () => {
+      component.selectedVehicle.set(mockVehicle1);
+      fixture.detectChanges();
+
+      const userLocationButtonComponent = fixture.nativeElement.querySelector('app-details-panel');
+      expect(userLocationButtonComponent).toBeTruthy();
+    });
+
+    it('should show confirm modal when showConfirmModal is true', () => {
+      component.showConfirmModal.set(true);
+      fixture.detectChanges();
+
+      const confirmModalComponent = fixture.nativeElement.querySelector('app-confirm-modal');
+
+      expect(confirmModalComponent).toBeTruthy();
+    });
+
+  });
+
+  
 });

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -516,4 +516,16 @@ describe('MapViewComponent', () => {
 
   });
 
+  describe('marker cleanup', () => {
+
+    it('should invoke cleanup functions from markerCleanups when clearing all markers');
+
+    it('should remove cleanup from markerCleanups after invoking it');
+
+    it('should invoke selectedMarkerCleanup when clearing selected marker');
+
+    it('should reset selectedMarkerCleanup to undefined after clearing');
+
+  });
+
 });


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/270)

## Summary
Update the existing `MapViewComponent` unit tests to reflect the vehicle marker refactoring (#256).
`MapViewComponent` is now responsible for mounting `VehicleMarkerComponent` instances through `VehicleMarkerManager` and cleaning them up when markers are removed.

## What's included
- Added coverage to verify `VehicleMarkerManager.mountComponent` is called when creating vehicle markers.
- Added coverage to verify cleanup functions are stored and executed through `markerCleanups` and `selectedMarkerCleanup`.
- Extracted duplicated vehicle mocks by reusing the shared `mockVehicle1` constant.
- Reset `VehicleMarkerManager` spies before each test to avoid state leakage between tests.
- Reorganized test suites to keep marker mounting and cleanup scenarios grouped separately.

## Notes
- No production code changes were required in `MapViewComponent`.
- Existing tests for map initialization, vehicle selection, dragging, location changes, and template rendering remain unchanged.
- This task only updates tests affected by the vehicle marker refactoring (#256).