### PR TITLE
test(map): Update MapService unit tests after vehicle marker refactoring (#269)

### DIFF
--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -12,7 +12,7 @@ function createMapDom() {
 }
 
 const mockVehicle: VehicleInterface = {
-  name: 'Ferrari LaFerrari',
+  name: 'Ferrari',
   model: 'LaFerrari',
   plate: 'F1234ABC',
   imageUrl: 'https://example.com/ferrari-laferrari.png',

--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -3,6 +3,7 @@ import * as L from 'leaflet';
 
 import { MapService } from './map-service';
 import { VehicleInterface } from '../../vehicle/interfaces/vehicle/vehicle';
+import { VehicleMarkerManager } from './vehicle-marker-manager';
 
 function createMapDom() {
   const div = document.createElement('div');
@@ -17,6 +18,11 @@ const mockVehicle: VehicleInterface = {
   imageUrl: 'https://example.com/ferrari-laferrari.png',
 };
 
+const vehicleMarkerManagerMock = {
+  createIcon: jasmine.createSpy('createIcon')
+    .and.returnValue(L.divIcon())
+};
+
 describe('MapService', () => {
   let service: MapService;
 
@@ -26,7 +32,14 @@ describe('MapService', () => {
   }
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: VehicleMarkerManager, useValue: vehicleMarkerManagerMock }
+      ]
+    });
+
+    vehicleMarkerManagerMock.createIcon.calls.reset();
+
     service = TestBed.inject(MapService);
   });
 

--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -157,7 +157,9 @@ describe('MapService', () => {
     });
 
     it('should delegate icon creation to vehicle marker manager when vehicle is provided', () => {
+      service.createMarker([41.3851, 2.1734], mockVehicle);
 
+      expect(vehicleMarkerManagerMock.createIcon).toHaveBeenCalled();
     });
 
   });

--- a/src/app/features/map/data-access/map-service.spec.ts
+++ b/src/app/features/map/data-access/map-service.spec.ts
@@ -156,6 +156,10 @@ describe('MapService', () => {
       expect(marker instanceof L.Marker).toBeTrue();
     });
 
+    it('should delegate icon creation to vehicle marker manager when vehicle is provided', () => {
+
+    });
+
   });
 
   describe('setView', () => {


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/269)

## Summary
Update the existing `MapService` unit tests to reflect the vehicle marker refactoring (#256), where vehicle icon creation was moved to `VehicleMarkerManager`.

## What's included
- Added a `VehicleMarkerManager` mock setup for `MapService` tests.
- Added coverage to verify that `createMarker()` delegates vehicle icon creation to `VehicleMarkerManager.createIcon()`.
- Verified existing marker creation, map lifecycle, and map interaction tests remain valid after the refactoring.

## Notes
- No production code changes were required in `MapService`.
- The existing location marker behaviour remains unchanged when no vehicle is provided.
- Vehicle marker rendering logic remains covered separately through `VehicleMarkerManager` and `VehicleMarkerComponent` tests.