### PR TITLE
test(vehicle-marker): Add unit test coverage for VehicleMarkerComponent (#267)

### DIFF
--- a/src/app/features/map/components/vehicle-marker/vehicle-marker.spec.ts
+++ b/src/app/features/map/components/vehicle-marker/vehicle-marker.spec.ts
@@ -56,7 +56,7 @@ describe('VehicleMarkerComponent', () => {
     it('should use the vehicle name as image alt text', () => {
       const vehicleImage: HTMLImageElement = fixture.nativeElement.querySelector('img');
 
-      expect(vehicleImage.alt).toContain(component.vehicle().name);
+      expect(vehicleImage.alt).toBe(component.vehicle().name);
     });
 
   });

--- a/src/app/features/map/components/vehicle-marker/vehicle-marker.spec.ts
+++ b/src/app/features/map/components/vehicle-marker/vehicle-marker.spec.ts
@@ -30,11 +30,20 @@ describe('VehicleMarkerComponent', () => {
   describe('image rendering', () => {
 
     it('should render the vehicle image when imageUrl is available', () => {
+      const vehicleImage: HTMLImageElement = fixture.nativeElement.querySelector('img');
 
+      expect(vehicleImage.src).toContain('test-image.jpg')
     });
 
     it('should render the fallback image when imageUrl is missing', () => {
+      fixture.componentRef.setInput('vehicle', {
+        ...component.vehicle(),
+        imageUrl: '',
+      });
+      fixture.detectChanges();
 
+      const vehicleImage: HTMLImageElement = fixture.nativeElement.querySelector('img');
+      expect(vehicleImage.src).toContain(component.fallbackImage);
     });
 
   });

--- a/src/app/features/map/components/vehicle-marker/vehicle-marker.spec.ts
+++ b/src/app/features/map/components/vehicle-marker/vehicle-marker.spec.ts
@@ -32,7 +32,7 @@ describe('VehicleMarkerComponent', () => {
     it('should render the vehicle image when imageUrl is available', () => {
       const vehicleImage: HTMLImageElement = fixture.nativeElement.querySelector('img');
 
-      expect(vehicleImage.src).toContain('test-image.jpg')
+      expect(vehicleImage.src).toContain('test-image.jpg');
     });
 
     it('should render the fallback image when imageUrl is missing', () => {
@@ -53,7 +53,7 @@ describe('VehicleMarkerComponent', () => {
     it('should use the vehicle name as image alt text', () => {
       const vehicleImage: HTMLImageElement = fixture.nativeElement.querySelector('img');
 
-      expect(vehicleImage.alt).toContain(component.vehicle().name)
+      expect(vehicleImage.alt).toContain(component.vehicle().name);
     });
 
   });

--- a/src/app/features/map/components/vehicle-marker/vehicle-marker.spec.ts
+++ b/src/app/features/map/components/vehicle-marker/vehicle-marker.spec.ts
@@ -1,7 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { VehicleMarkerComponent } from './vehicle-marker';
 
-const mockVehicle = {
+import { VehicleMarkerComponent } from './vehicle-marker';
+import { VehicleInterface } from '../../../vehicle/interfaces/vehicle/vehicle';
+
+const mockVehicle: VehicleInterface = {
   name: 'Ferrari',
   model: 'LaFerrari',
   plate: '1234ABC',

--- a/src/app/features/map/components/vehicle-marker/vehicle-marker.spec.ts
+++ b/src/app/features/map/components/vehicle-marker/vehicle-marker.spec.ts
@@ -51,7 +51,9 @@ describe('VehicleMarkerComponent', () => {
   describe('alt attribute', () => {
 
     it('should use the vehicle name as image alt text', () => {
+      const vehicleImage: HTMLImageElement = fixture.nativeElement.querySelector('img');
 
+      expect(vehicleImage.alt).toContain(component.vehicle().name)
     });
 
   });

--- a/src/app/features/map/components/vehicle-marker/vehicle-marker.spec.ts
+++ b/src/app/features/map/components/vehicle-marker/vehicle-marker.spec.ts
@@ -7,9 +7,8 @@ describe('VehicleMarkerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [VehicleMarkerComponent]
-    })
-    .compileComponents();
+      imports: [VehicleMarkerComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(VehicleMarkerComponent);
     component = fixture.componentInstance;
@@ -18,7 +17,7 @@ describe('VehicleMarkerComponent', () => {
       name: 'Ferrari',
       model: 'LaFerrari',
       plate: '1234ABC',
-      imageUrl: 'test-image.jpg'
+      imageUrl: 'test-image.jpg',
     });
 
     fixture.detectChanges();

--- a/src/app/features/map/components/vehicle-marker/vehicle-marker.spec.ts
+++ b/src/app/features/map/components/vehicle-marker/vehicle-marker.spec.ts
@@ -27,4 +27,25 @@ describe('VehicleMarkerComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('image rendering', () => {
+
+    it('should render the vehicle image when imageUrl is available', () => {
+
+    });
+
+    it('should render the fallback image when imageUrl is missing', () => {
+
+    });
+
+  });
+
+  describe('alt attribute', () => {
+
+    it('should use the vehicle name as image alt text', () => {
+
+    });
+
+  });
+
 });

--- a/src/app/features/map/components/vehicle-marker/vehicle-marker.spec.ts
+++ b/src/app/features/map/components/vehicle-marker/vehicle-marker.spec.ts
@@ -1,6 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { VehicleMarkerComponent } from './vehicle-marker';
 
+const mockVehicle = {
+  name: 'Ferrari',
+  model: 'LaFerrari',
+  plate: '1234ABC',
+  imageUrl: 'test-image.jpg',
+};
+
 describe('VehicleMarkerComponent', () => {
   let component: VehicleMarkerComponent;
   let fixture: ComponentFixture<VehicleMarkerComponent>;
@@ -13,13 +20,7 @@ describe('VehicleMarkerComponent', () => {
     fixture = TestBed.createComponent(VehicleMarkerComponent);
     component = fixture.componentInstance;
 
-    fixture.componentRef.setInput('vehicle', {
-      name: 'Ferrari',
-      model: 'LaFerrari',
-      plate: '1234ABC',
-      imageUrl: 'test-image.jpg',
-    });
-
+    fixture.componentRef.setInput('vehicle', mockVehicle);
     fixture.detectChanges();
   });
 


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/267)

## Summary
Add unit test coverage for `VehicleMarkerComponent`, the component responsible for rendering vehicle marker content, including vehicle image rendering, fallback image handling, and image accessibility attributes.

## What's included
- Added coverage to verify that the vehicle image is rendered using `vehicle().imageUrl` when available.
- Added coverage to verify that the fallback image is rendered when `imageUrl` is missing.
- Added coverage to verify that the image `alt` attribute uses `vehicle().name`.
- Extracted a reusable `mockVehicle` object for the component tests.
- Improved test assertions and typing by using `VehicleInterface` for the mock data.

## Notes
- No production code changes were required in `VehicleMarkerComponent`.
- The existing vehicle marker rendering behaviour remains unchanged.
- The tests only cover the current component behaviour extracted in the previous vehicle marker refactoring.