### PR TITLE
test(map): Add VehicleMarkerManager unit test coverage (#268)

### DIFF
--- a/src/app/features/map/data-access/vehicle-marker-manager.spec.ts
+++ b/src/app/features/map/data-access/vehicle-marker-manager.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import L from 'leaflet';
 
 import { VehicleMarkerManager } from './vehicle-marker-manager';
 import { VehicleInterface } from '../../vehicle/interfaces/vehicle/vehicle';
@@ -46,7 +47,12 @@ describe('VehicleMarkerManager', () => {
   describe('createIcon', () => {
 
     it('should return a Leaflet DivIcon with the expected configuration', () => {
+      const icon = service.createIcon();
 
+      expect(icon).toEqual(jasmine.any(L.DivIcon));
+      expect(icon.options.className).toBe('vehicle-marker-host');
+      expect(icon.options.iconSize).toEqual([75, 75]);
+      expect(icon.options.iconAnchor).toEqual([24, 24]);
     });
 
   });

--- a/src/app/features/map/data-access/vehicle-marker-manager.spec.ts
+++ b/src/app/features/map/data-access/vehicle-marker-manager.spec.ts
@@ -1,6 +1,14 @@
 import { TestBed } from '@angular/core/testing';
 
 import { VehicleMarkerManager } from './vehicle-marker-manager';
+import { VehicleInterface } from '../../vehicle/interfaces/vehicle/vehicle';
+
+const mockVehicle: VehicleInterface = {
+  name: 'Ferrari',
+  model: 'LaFerrari',
+  plate: '1234ABC',
+  imageUrl: 'test-image.jpg',
+};
 
 describe('VehicleMarkerManager', () => {
   let service: VehicleMarkerManager;

--- a/src/app/features/map/data-access/vehicle-marker-manager.spec.ts
+++ b/src/app/features/map/data-access/vehicle-marker-manager.spec.ts
@@ -13,4 +13,33 @@ describe('VehicleMarkerManager', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  describe('createIcon', () => {
+
+    it('should return a Leaflet DivIcon with the expected configuration', () => {
+
+    });
+
+  });
+
+  describe('mountComponent', () => {
+
+    it('should create a VehicleMarkerComponent instance', () => {
+
+    });
+
+    it('should set the vehicle input on the created component', () => {
+
+    });
+
+    it('should append the component native element to the marker element', () => {
+
+    });
+
+    it('should destroy the component when cleanup is called', () => {
+
+    });
+
+  });
+
 });

--- a/src/app/features/map/data-access/vehicle-marker-manager.spec.ts
+++ b/src/app/features/map/data-access/vehicle-marker-manager.spec.ts
@@ -69,6 +69,7 @@ describe('VehicleMarkerManager', () => {
       );
 
       expect(viewContainerRefMock.createComponent).toHaveBeenCalledWith(VehicleMarkerComponent);
+      expect(componentRefMock.changeDetectorRef.detectChanges).toHaveBeenCalled();
     });
 
     it('should set the vehicle input on the created component', () => {

--- a/src/app/features/map/data-access/vehicle-marker-manager.spec.ts
+++ b/src/app/features/map/data-access/vehicle-marker-manager.spec.ts
@@ -29,6 +29,10 @@ const viewContainerRefMock = {
     .and.returnValue(componentRefMock),
 };
 
+const markerMock = {
+  getElement: jasmine.createSpy('getElement'),
+};
+
 describe('VehicleMarkerManager', () => {
   let service: VehicleMarkerManager;
 
@@ -40,6 +44,7 @@ describe('VehicleMarkerManager', () => {
     componentRefMock.changeDetectorRef.detectChanges.calls.reset();
     componentRefMock.destroy.calls.reset();
     viewContainerRefMock.createComponent.calls.reset();
+    markerMock.getElement.calls.reset();
   });
 
   it('should be created', () => {
@@ -86,12 +91,10 @@ describe('VehicleMarkerManager', () => {
       const markerElement = document.createElement('div');
       const appendChildSpy = spyOn(markerElement, 'appendChild');
 
-      const marker = {
-        getElement: jasmine.createSpy('getElement').and.returnValue(markerElement),
-      } as unknown as L.Marker;
+      markerMock.getElement.and.returnValue(markerElement);
 
       service.mountComponent(
-        marker,
+        markerMock as unknown as L.Marker,
         mockVehicle,
         viewContainerRefMock as unknown as ViewContainerRef
       );

--- a/src/app/features/map/data-access/vehicle-marker-manager.spec.ts
+++ b/src/app/features/map/data-access/vehicle-marker-manager.spec.ts
@@ -10,6 +10,10 @@ const mockVehicle: VehicleInterface = {
   imageUrl: 'test-image.jpg',
 };
 
+const viewContainerRefMock = {
+  createComponent: jasmine.createSpy('createComponent'),
+};
+
 describe('VehicleMarkerManager', () => {
   let service: VehicleMarkerManager;
 

--- a/src/app/features/map/data-access/vehicle-marker-manager.spec.ts
+++ b/src/app/features/map/data-access/vehicle-marker-manager.spec.ts
@@ -1,7 +1,9 @@
 import { TestBed } from '@angular/core/testing';
+import { ViewContainerRef } from '@angular/core';
 import L from 'leaflet';
 
 import { VehicleMarkerManager } from './vehicle-marker-manager';
+import { VehicleMarkerComponent } from '../components/vehicle-marker/vehicle-marker';
 import { VehicleInterface } from '../../vehicle/interfaces/vehicle/vehicle';
 
 const mockVehicle: VehicleInterface = {
@@ -60,19 +62,52 @@ describe('VehicleMarkerManager', () => {
   describe('mountComponent', () => {
 
     it('should create a VehicleMarkerComponent instance', () => {
+      service.mountComponent(
+        {} as L.Marker,
+        mockVehicle,
+        viewContainerRefMock as unknown as ViewContainerRef
+      );
 
+      expect(viewContainerRefMock.createComponent).toHaveBeenCalledWith(VehicleMarkerComponent);
     });
 
     it('should set the vehicle input on the created component', () => {
+      service.mountComponent(
+        {} as L.Marker,
+        mockVehicle,
+        viewContainerRefMock as unknown as ViewContainerRef
+      );
 
+      expect(componentRefMock.setInput).toHaveBeenCalledWith('vehicle', mockVehicle);
     });
 
-    it('should append the component native element to the marker element', () => {
+    it('should append the component native element to the marker element', async () => {
+      const markerElement = document.createElement('div');
+      const appendChildSpy = spyOn(markerElement, 'appendChild');
 
+      const marker = {
+        getElement: jasmine.createSpy('getElement').and.returnValue(markerElement),
+      } as unknown as L.Marker;
+
+      service.mountComponent(
+        marker,
+        mockVehicle,
+        viewContainerRefMock as unknown as ViewContainerRef
+      );
+      await Promise.resolve();
+
+      expect(appendChildSpy).toHaveBeenCalledWith(componentRefMock.location.nativeElement);
     });
 
     it('should destroy the component when cleanup is called', () => {
+      const cleanup = service.mountComponent(
+        {} as L.Marker,
+        mockVehicle,
+        viewContainerRefMock as unknown as ViewContainerRef
+      );
+      cleanup();
 
+      expect(componentRefMock.destroy).toHaveBeenCalled();
     });
 
   });

--- a/src/app/features/map/data-access/vehicle-marker-manager.spec.ts
+++ b/src/app/features/map/data-access/vehicle-marker-manager.spec.ts
@@ -10,8 +10,20 @@ const mockVehicle: VehicleInterface = {
   imageUrl: 'test-image.jpg',
 };
 
+const componentRefMock = {
+  setInput: jasmine.createSpy('setInput'),
+  changeDetectorRef: {
+    detectChanges: jasmine.createSpy('detectChanges'),
+  },
+  location: {
+    nativeElement: document.createElement('div'),
+  },
+  destroy: jasmine.createSpy('destroy'),
+};
+
 const viewContainerRefMock = {
-  createComponent: jasmine.createSpy('createComponent'),
+  createComponent: jasmine.createSpy('createComponent')
+    .and.returnValue(componentRefMock),
 };
 
 describe('VehicleMarkerManager', () => {
@@ -20,6 +32,11 @@ describe('VehicleMarkerManager', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({});
     service = TestBed.inject(VehicleMarkerManager);
+
+    componentRefMock.setInput.calls.reset();
+    componentRefMock.changeDetectorRef.detectChanges.calls.reset();
+    componentRefMock.destroy.calls.reset();
+    viewContainerRefMock.createComponent.calls.reset();
   });
 
   it('should be created', () => {


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/268)

## Summary
Add unit test coverage for `VehicleMarkerManager`, the service responsible for creating vehicle marker Leaflet icons and mounting `VehicleMarkerComponent` instances inside Leaflet markers.

## What's included
- Added coverage for `createIcon()` to verify the generated `DivIcon` configuration.
- Added coverage for `mountComponent()` to verify component creation through `ViewContainerRef`.
- Added coverage to verify vehicle input assignment and component change detection.
- Added coverage to verify component mounting inside the marker element.
- Added coverage to verify component cleanup and destruction.

## Notes
- No production code changes were required in `VehicleMarkerManager`.
- Existing vehicle marker behaviour remains unchanged.
- The new tests only cover the existing implementation introduced in #256.