### PR TITLE
feat(map): Select vehicles directly from map markers (#258)

### DIFF
--- a/src/app/features/map/components/map-view/map-view.html
+++ b/src/app/features/map/components/map-view/map-view.html
@@ -3,6 +3,7 @@
     <app-vehicle-selector
         class="map-view__vehicle-selector"
         [vehicles]="vehicles()"
+        [selectedPlate]="selectedVehicle()?.plate ?? null"
         (vehicleSelected)="showVehicle($event)"
     />
 

--- a/src/app/features/map/components/map-view/map-view.ts
+++ b/src/app/features/map/components/map-view/map-view.ts
@@ -98,6 +98,7 @@ export class MapViewComponent implements OnInit, OnDestroy {
 
       this.markerCleanups.set(marker, destroy);
       this.allVehicleMarkers.push(marker);
+
       bounds.extend(coords);
     });
 

--- a/src/app/features/map/components/map-view/map-view.ts
+++ b/src/app/features/map/components/map-view/map-view.ts
@@ -79,12 +79,24 @@ export class MapViewComponent implements OnInit, OnDestroy {
     vehicleList.forEach(vehicle => {
       if (!vehicle.location) return;
 
-      const coords: [number, number] = [vehicle.location.lat, vehicle.location.lng];
+      const coords: [number, number] = [
+        vehicle.location.lat,
+        vehicle.location.lng
+      ];
+
       const marker = this.mapService.createMarker(coords, vehicle, false);
 
-      const destroy = this.vehicleMarkerManager.mountComponent(marker, vehicle, this.viewContainerRef);
-      this.markerCleanups.set(marker, destroy);
+      marker.on('click', () => {
+        this.showVehicle(vehicle);
+      });
 
+      const destroy = this.vehicleMarkerManager.mountComponent(
+        marker,
+        vehicle,
+        this.viewContainerRef
+      );
+
+      this.markerCleanups.set(marker, destroy);
       this.allVehicleMarkers.push(marker);
       bounds.extend(coords);
     });

--- a/src/app/features/vehicle/components/vehicle-selector/vehicle-selector.html
+++ b/src/app/features/vehicle/components/vehicle-selector/vehicle-selector.html
@@ -2,17 +2,17 @@
 <select
   id="vehicle-select"
   class="vehicle-select"
+  [value]="selectedPlate() ?? ''"
   (change)="onVehicleChange($event)"
   aria-required="true"
 >
-  <option class="vehicle-select__option" value="" selected>
+  <option class="vehicle-select__option" value="">
     {{ selectorMsg.allVehiclesOption }}
   </option>
   @for (vehicle of vehicles(); track vehicle.plate) {
     <option
       class="vehicle-select__option"
       [value]="vehicle.plate"
-      [selected]="vehicle.plate === selectedPlate()"
     >
       {{ vehicle.name }}
     </option>

--- a/src/app/features/vehicle/components/vehicle-selector/vehicle-selector.html
+++ b/src/app/features/vehicle/components/vehicle-selector/vehicle-selector.html
@@ -1,4 +1,7 @@
-<label for="vehicle-select" class="sr-only">{{ selectorMsg.label }}</label>
+<label for="vehicle-select" class="sr-only">
+  {{ selectorMsg.label }}
+</label>
+
 <select
   id="vehicle-select"
   class="vehicle-select"
@@ -6,9 +9,13 @@
   (change)="onVehicleChange($event)"
   aria-required="true"
 >
-  <option class="vehicle-select__option" value="">
+  <option 
+    class="vehicle-select__option" 
+    value=""
+  >
     {{ selectorMsg.allVehiclesOption }}
   </option>
+
   @for (vehicle of vehicles(); track vehicle.plate) {
     <option
       class="vehicle-select__option"
@@ -17,4 +24,5 @@
       {{ vehicle.name }}
     </option>
   }
+  
 </select>

--- a/src/app/features/vehicle/components/vehicle-selector/vehicle-selector.ts
+++ b/src/app/features/vehicle/components/vehicle-selector/vehicle-selector.ts
@@ -18,13 +18,13 @@ export class VehicleSelectorComponent {
   vehicles = input<VehicleInterface[]>([]);
   selectedPlate = input<string | null>(null);
 
-  vehicleSelected = output<VehicleInterface>();
+  public vehicleSelected = output<VehicleInterface | null>();
 
   onVehicleChange(event: Event): void {
     const plate = (event.target as HTMLSelectElement).value;
 
     if (!plate) {
-      this.vehicleSelected.emit(null as any);
+      this.vehicleSelected.emit(null);
       return;
     }
 


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/258)

## Summary

Introduce vehicle selection through map marker interactions by allowing users to select a vehicle directly from the map when viewing all vehicles.

The existing vehicle selection flow has been reused so marker selection behaves the same way as selecting a vehicle from the selector component, while keeping existing map behavior and vehicle location management unchanged.

## What's included

- Added click interaction to vehicle markers in the all vehicles view.
- Reused the existing `showVehicle()` flow for marker-based selection.
- Updated `VehicleSelectorComponent` to support external selected vehicle synchronization.
- Updated `MapViewComponent` to keep the vehicle selector synchronized with map selections.
- Improved selector value handling by making the selected vehicle state the source of truth.
- Preserved selected vehicle draggable marker behavior.
- Preserved existing vehicle location update and confirmation flows.
- Improved vehicle selector template formatting and readability.
- Improved map view component formatting and readability.

## Notes

- No backend changes were required.
- No vehicle persistence changes were introduced.
- `MapService` remains responsible only for map utilities and marker creation.
- Existing vehicle selection and location update flows are preserved.
