### PR TITLE
test(map-view): Add MapViewComponent test coverage for new vehicle selection flow (#280)

### DIFF
--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -99,14 +99,7 @@ describe('MapViewComponent', () => {
   describe('initialization', () => {
 
     it('should initialize the map on ngOnInit', () => {
-      const mapService = TestBed.inject(MapService);
-      const mockMap = {} as L.Map;
 
-      const initMapSpy = spyOn(mapService, 'initMap').and.returnValue(mockMap);
-
-      component.ngOnInit();
-
-      expect(initMapSpy).toHaveBeenCalledOnceWith('map', [41.478, 2.31], 10);
     });
 
     it('should clear markers on ngOnDestroy', () => {

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -261,7 +261,18 @@ describe('MapViewComponent', () => {
     });
 
     it('should register dragend handler for the selected marker', () => {
+      const mapService = TestBed.inject(MapService);
+      const onSpy = jasmine.createSpy('on');
+      const mockMarker = {
+        on: onSpy,
+      } as unknown as L.Marker;
 
+      spyOn(mapService, 'createMarker').and.returnValue(mockMarker);
+      
+      component.selectedVehicle.set(mockVehicle1);
+      (component as any).placeSelectedVehicleMarker([41, 2]);
+
+      expect(onSpy).toHaveBeenCalledWith('dragend', jasmine.any(Function));
     });
 
   });

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -203,6 +203,18 @@ describe('MapViewComponent', () => {
       expect(mapService.createMarker).not.toHaveBeenCalled();
     });
 
+    it('should clear all vehicle markers before showing the selected vehicle', () => {
+
+    });
+
+    it('should clear all vehicle markers when clearing the selection', () => {
+
+    });
+
+    it('should replace the previous selected marker when selecting another vehicle', () => {
+
+    });
+
   });
 
   describe('vehicle marker drag behaviour', () => {

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -99,7 +99,14 @@ describe('MapViewComponent', () => {
   describe('initialization', () => {
 
     it('should initialize the map on ngOnInit', () => {
+      const mapService = TestBed.inject(MapService);
+      const mockMap = {} as L.Map;
 
+      const initMapSpy = spyOn(mapService, 'initMap').and.returnValue(mockMap);
+
+      component.ngOnInit();
+
+      expect(initMapSpy).toHaveBeenCalledOnceWith('map', [41.478, 2.31], 10);
     });
 
     it('should clear markers on ngOnDestroy', () => {

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -185,7 +185,10 @@ describe('MapViewComponent', () => {
 
     it('should create markers for all vehicles with location', () => {
       const mapService = TestBed.inject(MapService);
-      const markerMock = {} as L.Marker;
+
+      const markerMock = {
+        on: jasmine.createSpy('on'),
+      } as unknown as L.Marker;
 
       spyOn(mapService, 'createMarker').and.returnValue(markerMock);
 
@@ -596,5 +599,4 @@ describe('MapViewComponent', () => {
 
   });
 
-  
 });

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -514,6 +514,10 @@ describe('MapViewComponent', () => {
       expect((component as any).selectedMarkerCleanup).toBe(cleanupFn);
     });
 
+    it('should register click handler for each vehicle marker', () => {
+
+    });
+
   });
 
   describe('marker cleanup', () => {

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -237,6 +237,10 @@ describe('MapViewComponent', () => {
       expect(component.showConfirmModal()).toBe(true);
     });
 
+    it('should register dragend handler for the selected marker', () => {
+
+    });
+
   });
 
   describe('confirm location change', () => {

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -211,15 +211,31 @@ describe('MapViewComponent', () => {
     });
 
     it('should clear all vehicle markers before showing the selected vehicle', () => {
+      const clearAllMarkersSpy = spyOn<any>(component, 'clearAllMarkers');
 
+      component.showVehicle(mockVehicle1);
+
+      expect(clearAllMarkersSpy).toHaveBeenCalled();
     });
 
     it('should clear all vehicle markers when clearing the selection', () => {
+      const clearAllMarkersSpy = spyOn<any>(component, 'clearAllMarkers');
 
+      component.showVehicle(null);
+
+      expect(clearAllMarkersSpy).toHaveBeenCalled();
     });
 
     it('should replace the previous selected marker when selecting another vehicle', () => {
+      const mapService = TestBed.inject(MapService);
+      const removeLayerSpy = spyOn(mapService, 'removeLayer');
 
+      const previousMarker = {} as L.Marker;
+      (component as any).selectedVehicleMarker = previousMarker;
+
+      component.showVehicle(mockVehicle1);
+
+      expect(removeLayerSpy).toHaveBeenCalledOnceWith(previousMarker);
     });
 
   });

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -584,6 +584,17 @@ describe('MapViewComponent', () => {
 
   });
 
+  describe('vehicle selection synchronization', () => {
+
+    it('should keep selectedVehicle synchronized after selecting a vehicle', () => {
+
+    });
+
+    it('should clear selectedVehicle when selection is cleared', () => {
+
+    });
+
+  });
 
   describe('template integration', () => {
 

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -565,7 +565,19 @@ describe('MapViewComponent', () => {
     });
 
     it('should register click handler for each vehicle marker', () => {
+      const mapService = TestBed.inject(MapService);
+      const onSpy = jasmine.createSpy('on');
+      const mockMarker = {
+        on: onSpy,
+      } as unknown as L.Marker;
 
+      spyOn(mapService, 'createMarker').and.returnValue(mockMarker);
+
+      vehicleService.vehicles.set([mockVehicle1, mockVehicle2]);
+
+      (component as any).showAllVehicles();
+
+      expect(onSpy).toHaveBeenCalledWith('click', jasmine.any(Function));
     });
 
   });

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -68,7 +68,9 @@ describe('MapViewComponent', () => {
 
   beforeEach(async () => {
     vehicleMarkerManagerMock.mountComponent.calls.reset();
+    vehicleMarkerManagerMock.mountComponent.and.returnValue(() => {});
     vehicleMarkerManagerMock.createIcon.calls.reset();
+    vehicleMarkerManagerMock.createIcon.and.returnValue(L.divIcon());
 
     vehicleServiceMock.vehicles.set([]);
     vehicleServiceMock.loadVehicles.calls.reset();

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -438,7 +438,23 @@ describe('MapViewComponent', () => {
     });
 
     it('should center the map after updating to the user location', async () => {
+      const geo = TestBed.inject(GeolocationService);
+      const mapService = TestBed.inject(MapService);
 
+      spyOn(geo, 'getCurrentLocation').and.returnValue(
+        Promise.resolve([50, 8])
+      );
+      spyOn(mapService, 'createMarker').and.returnValue({
+        on: jasmine.createSpy('on')
+      } as any);
+
+      const setViewSpy = spyOn(mapService, 'setView');
+
+      component.selectedVehicle.set(mockVehicle1);
+
+      await component.onUserLocationClick();
+
+      expect(setViewSpy).toHaveBeenCalledWith([50, 8], 19);
     });
 
   });

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -52,23 +52,30 @@ const mockVehicleWithoutLocation: VehicleInterface = {
   location: undefined
 };
 
+const vehicleServiceMock = {
+  vehicles: signal<VehicleInterface[]>([]),
+  loadVehicles: jasmine.createSpy('loadVehicles'),
+  addVehicle: jasmine.createSpy('addVehicle'),
+  updateVehicle: jasmine.createSpy('updateVehicle'),
+  deleteVehicle: jasmine.createSpy('deleteVehicle'),
+  updateVehicleLocation: jasmine.createSpy('updateVehicleLocation')
+};
+
 describe('MapViewComponent', () => {
   let component: MapViewComponent;
   let fixture: ComponentFixture<MapViewComponent>;
   let vehicleService: any;
 
   beforeEach(async () => {
-    const vehicleServiceMock = {
-      vehicles: signal<VehicleInterface[]>([]),
-      loadVehicles: jasmine.createSpy('loadVehicles'),
-      addVehicle: jasmine.createSpy('addVehicle'),
-      updateVehicle: jasmine.createSpy('updateVehicle'),
-      deleteVehicle: jasmine.createSpy('deleteVehicle'),
-      updateVehicleLocation: jasmine.createSpy('updateVehicleLocation')
-    };
-
     vehicleMarkerManagerMock.mountComponent.calls.reset();
     vehicleMarkerManagerMock.createIcon.calls.reset();
+
+    vehicleServiceMock.vehicles.set([]);
+    vehicleServiceMock.loadVehicles.calls.reset();
+    vehicleServiceMock.addVehicle.calls.reset();
+    vehicleServiceMock.updateVehicle.calls.reset();
+    vehicleServiceMock.deleteVehicle.calls.reset();
+    vehicleServiceMock.updateVehicleLocation.calls.reset();
 
     await TestBed.configureTestingModule({
       imports: [MapViewComponent],

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -649,11 +649,16 @@ describe('MapViewComponent', () => {
   describe('vehicle selection synchronization', () => {
 
     it('should keep selectedVehicle synchronized after selecting a vehicle', () => {
+      component.showVehicle(mockVehicle1);
 
+      expect(component.selectedVehicle()).toBe(mockVehicle1);
     });
 
     it('should clear selectedVehicle when selection is cleared', () => {
+      component.selectedVehicle.set(mockVehicle1);
+      component.showVehicle(null);
 
+      expect(component.selectedVehicle()).toBeNull();
     });
 
   });

--- a/src/app/features/map/components/map-view/map-view.spec.ts
+++ b/src/app/features/map/components/map-view/map-view.spec.ts
@@ -403,6 +403,10 @@ describe('MapViewComponent', () => {
       expect(console.error).toHaveBeenCalled();
     });
 
+    it('should center the map after updating to the user location', async () => {
+
+    });
+
   });
 
   describe('private helper methods', () => {


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/280)

## Summary
Improve test coverage for `MapViewComponent` after the vehicle selector refactor, covering the vehicle selection flow, map interactions, marker lifecycle and user location behaviour with the current signal-based implementation.

## What's included
- Added coverage for map initialization and component lifecycle behaviour.
- Added coverage for vehicle selection flow between the map and vehicle selector state.
- Added coverage to verify vehicle marker creation, click handling and selected marker drag behaviour.
- Added coverage for vehicle marker cleanup and replacement when changing selected vehicles.
- Added coverage for confirmation modal related location updates.
- Added coverage for user location updates and map repositioning.
- Updated marker mocks affected by the vehicle selection refactor.
- Extracted service mocks outside beforeEach for reuse across tests.
- Reset mocks between tests to avoid shared state.

## Notes
- No production code changes were introduced.
- Existing `MapViewComponent` behaviour remains unchanged.
- The new tests only validate existing flows introduced by the vehicle selector refactor.
- Changes are limited to test coverage improvements for `MapViewComponent`.