### PR TITLE
test(vehicle): Improve test coverage and readability across vehicle feature (#286)

### DIFF
--- a/src/app/features/vehicle/components/vehicle-empty-state/vehicle-empty-state.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-empty-state/vehicle-empty-state.spec.ts
@@ -49,6 +49,7 @@ describe('VehicleEmptyStateComponent', () => {
 
     it('should render the create button', () => {
       const button = fixture.debugElement.query(By.css('app-create-button'));
+      
       expect(button).toBeTruthy();
     });
 

--- a/src/app/features/vehicle/components/vehicle-empty-state/vehicle-empty-state.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-empty-state/vehicle-empty-state.spec.ts
@@ -61,7 +61,7 @@ describe('VehicleEmptyStateComponent', () => {
     it('should pass create text to create button', () => {
       const button = fixture.debugElement.query(By.css('app-create-button'));
 
-      expect(button.componentInstance.createText).toBeTruthy();
+      expect(button.componentInstance.createText()).toBe(component.emptyStateMsg.button);
     });
 
   });

--- a/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
@@ -122,7 +122,7 @@ describe('VehicleTableActionsComponent', () => {
       const options = select.querySelectorAll('option');
 
       expect(select).toBeTruthy();
-      expect(options.length).toBe(3);
+      expect(options).toHaveSize(3);
     });
 
     it('should show asc icon when sortDir is asc', () => {

--- a/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-actions/vehicle-table-actions.spec.ts
@@ -109,11 +109,13 @@ describe('VehicleTableActionsComponent', () => {
 
     it('should render search input', () => {
       const input = fixture.nativeElement.querySelector('.vehicle-actions__search-input');
+
       expect(input).toBeTruthy();
     });
 
     it('should render sort direction button', () => {
       const button = fixture.nativeElement.querySelector('.vehicle-actions__sort-button');
+
       expect(button).toBeTruthy();
     });
 
@@ -130,6 +132,7 @@ describe('VehicleTableActionsComponent', () => {
       fixture.detectChanges();
 
       const icon = fixture.nativeElement.querySelector('.vehicle-actions__sort-button i');
+
       expect(icon.classList).toContain('pi-sort-amount-down');
     });
 
@@ -138,6 +141,7 @@ describe('VehicleTableActionsComponent', () => {
       fixture.detectChanges();
 
       const icon = fixture.nativeElement.querySelector('.vehicle-actions__sort-button i');
+
       expect(icon.classList).toContain('pi-sort-amount-up');
     });
 
@@ -178,21 +182,25 @@ describe('VehicleTableActionsComponent', () => {
 
     it('should have aria-label on search input', () => {
       const input = fixture.nativeElement.querySelector('.vehicle-actions__search-input');
+
       expect(input.getAttribute('aria-label')).toBe(component.actionsMsg.aria.searchInput);
     });
 
     it('should have aria-label on sort direction button', () => {
       const button = fixture.nativeElement.querySelector('.vehicle-actions__sort-button');
+
       expect(button.getAttribute('aria-label')).toBe(component.actionsMsg.aria.sortDirButton);
     });
 
     it('should have aria-label on sort field select', () => {
       const select = fixture.nativeElement.querySelector('.vehicle-actions__sort-select');
+
       expect(select.getAttribute('aria-label')).toBe(component.actionsMsg.aria.sortFieldSelect);
     });
 
     it('should have aria-hidden on search icon', () => {
       const icon = fixture.nativeElement.querySelector('.vehicle-actions__search-icon');
+      
       expect(icon.getAttribute('aria-hidden')).toBe('true');
     });
 

--- a/src/app/features/vehicle/components/vehicle-table-pagination/vehicle-table-pagination.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-pagination/vehicle-table-pagination.spec.ts
@@ -78,7 +78,8 @@ describe('VehicleTablePaginationComponent', () => {
 
     it('should render next page button', () => {
       const buttons = fixture.nativeElement.querySelectorAll('.vehicle-pagination__button');
-      expect(buttons.length).toBe(2);
+
+      expect(buttons).toHaveSize(2);
     });
 
   });

--- a/src/app/features/vehicle/components/vehicle-table-pagination/vehicle-table-pagination.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table-pagination/vehicle-table-pagination.spec.ts
@@ -67,12 +67,14 @@ describe('VehicleTablePaginationComponent', () => {
       fixture.detectChanges();
 
       const values = fixture.nativeElement.querySelectorAll('.vehicle-pagination__value');
+
       expect(values[0].textContent.trim()).toBe('2');
       expect(values[1].textContent.trim()).toBe('2');
     });
 
     it('should render previous page button', () => {
       const button = fixture.nativeElement.querySelector('.vehicle-pagination__button:first-of-type');
+
       expect(button).toBeTruthy();
     });
 
@@ -88,11 +90,13 @@ describe('VehicleTablePaginationComponent', () => {
 
     it('should have aria-label on previous page button', () => {
       const button = fixture.nativeElement.querySelector('.vehicle-pagination__button:first-of-type');
+
       expect(button.getAttribute('aria-label')).toBe(component.paginationMsg.aria.previousPage);
     });
 
     it('should have aria-label on next page button', () => {
       const buttons = fixture.nativeElement.querySelectorAll('.vehicle-pagination__button');
+      
       expect(buttons[1].getAttribute('aria-label')).toBe(component.paginationMsg.aria.nextPage);
     });
 

--- a/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
@@ -99,7 +99,7 @@ describe('VehicleTableComponent', () => {
 
     it('should render one table row per vehicle', () => {
       const rows = fixture.nativeElement.querySelectorAll('tbody tr');
-      expect(rows.length).toBe(mockVehicles.length);
+      expect(rows).toHaveSize(mockVehicles.length);
     });
 
     it('should render vehicle name, model and plate in each row', () => {
@@ -118,8 +118,8 @@ describe('VehicleTableComponent', () => {
       const editButtons = fixture.nativeElement.querySelectorAll('app-edit-button');
       const deleteButtons = fixture.nativeElement.querySelectorAll('app-delete-button');
 
-      expect(editButtons.length).toBe(mockVehicles.length);
-      expect(deleteButtons.length).toBe(mockVehicles.length);
+      expect(editButtons).toHaveSize(mockVehicles.length);
+      expect(deleteButtons).toHaveSize(mockVehicles.length);
     });
 
   });
@@ -160,7 +160,7 @@ describe('VehicleTableComponent', () => {
       fixture.detectChanges();
 
       const rowsAfter = fixture.nativeElement.querySelectorAll('tbody tr');
-      expect(rowsAfter.length).toBe(rowsBefore.length);
+      expect(rowsAfter).toHaveSize(rowsBefore.length);
     });
     
   });
@@ -190,8 +190,8 @@ describe('VehicleTableComponent', () => {
       const editButtons = fixture.nativeElement.querySelectorAll('app-edit-button');
       const deleteButtons = fixture.nativeElement.querySelectorAll('app-delete-button');
 
-      expect(editButtons.length).toBe(0);
-      expect(deleteButtons.length).toBe(0);
+      expect(editButtons).toHaveSize(0);
+      expect(deleteButtons).toHaveSize(0);
     });
 
   });

--- a/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-table/vehicle-table.spec.ts
@@ -230,7 +230,8 @@ describe('VehicleTableComponent', () => {
     it('should use fallback image when vehicle has no imageUrl', () => {
       const images = fixture.nativeElement.querySelectorAll('.vehicle-table__image');
 
-      expect(images[0].getAttribute('src')).toBe(component.vehicleImage);
+      expect(images).toHaveSize(mockVehicles.length);
+      expect(images[0].src).toContain(component.vehicleImage);
     });
 
   });

--- a/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
@@ -326,7 +326,7 @@ describe('VehicleViewComponent', () => {
       component.onFilterChange({ query: 'ferrari', sortField: 'name', sortDir: 'asc' });
 
       const result = component.filteredVehicles();
-      expect(result.length).toBe(1);
+      expect(result).toHaveSize(1); 
       expect(result[0].name).toBe('Ferrari');
     });
 
@@ -334,7 +334,7 @@ describe('VehicleViewComponent', () => {
       component.onFilterChange({ query: 'aventador', sortField: 'name', sortDir: 'asc' });
 
       const result = component.filteredVehicles();
-      expect(result.length).toBe(1);
+      expect(result).toHaveSize(1);
       expect(result[0].model).toBe('Aventador');
     });
 
@@ -342,7 +342,7 @@ describe('VehicleViewComponent', () => {
       component.onFilterChange({ query: 'pag0001', sortField: 'name', sortDir: 'asc' });
 
       const result = component.filteredVehicles();
-      expect(result.length).toBe(1);
+      expect(result).toHaveSize(1);
       expect(result[0].plate).toBe('PAG0001');
     });
 
@@ -350,7 +350,7 @@ describe('VehicleViewComponent', () => {
       component.onFilterChange({ query: '', sortField: 'name', sortDir: 'asc' });
 
       const result = component.filteredVehicles();
-      expect(result.length).toBe(3);
+      expect(result).toHaveSize(3);
     });
 
     it('should sort vehicles ascending by default field', () => {

--- a/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
+++ b/src/app/features/vehicle/components/vehicle-view/vehicle-view.spec.ts
@@ -369,6 +369,18 @@ describe('VehicleViewComponent', () => {
       expect(result[2].name).toBe('Ferrari');
     });
 
+    it('should update filterState with new filter values', () => {
+      const newState = { 
+        query: 'ferrari', 
+        sortField: 'name' as const, 
+        sortDir: 'asc' as const 
+      };
+
+      component.onFilterChange(newState);
+
+      expect(component.filterState()).toEqual(newState);
+    });
+
   });
 
   describe('Add user to vehicle', () => {

--- a/src/app/features/vehicle/modals/manage-vehicle-users-modal/manage-vehicle-users-modal.spec.ts
+++ b/src/app/features/vehicle/modals/manage-vehicle-users-modal/manage-vehicle-users-modal.spec.ts
@@ -271,7 +271,7 @@ describe('ManageVehicleUsersModalComponent', () => {
 
       const users = fixture.nativeElement.querySelectorAll('.modal__user');
 
-      expect(users.length).toBe(1);
+      expect(users).toHaveSize(1);
       expect(users[0].textContent).toContain('test@gmail.com');
     });
 

--- a/src/app/features/vehicle/state/vehicle-modal-service.spec.ts
+++ b/src/app/features/vehicle/state/vehicle-modal-service.spec.ts
@@ -65,7 +65,7 @@ describe('VehicleModalService', () => {
     });
 
     it('should initialize selectedVehicle as null', () => {
-      expect(service.selectedVehicle()).toBe(null);
+      expect(service.selectedVehicle()).toBeNull();
     });
 
   });
@@ -76,7 +76,7 @@ describe('VehicleModalService', () => {
       service.openCreate();
 
       expect(service.formMode()).toBe('create');
-      expect(service.selectedVehicle()).toBe(null);
+      expect(service.selectedVehicle()).toBeNull();
       expect(service.activeModal()).toBe(VehicleModalState.VehicleForm);
     });
 
@@ -87,7 +87,7 @@ describe('VehicleModalService', () => {
       service.openCreate();
 
       expect(service.formMode()).toBe('create');
-      expect(service.selectedVehicle()).toBe(null);
+      expect(service.selectedVehicle()).toBeNull();
       expect(service.activeModal()).toBe(VehicleModalState.VehicleForm);
     });
 
@@ -148,7 +148,7 @@ describe('VehicleModalService', () => {
       service.openEdit(mockVehicle);
       service.close();
 
-      expect(service.selectedVehicle()).toBe(null);
+      expect(service.selectedVehicle()).toBeNull();
     });
 
     it('should reset formMode to create when closing modal', () => {
@@ -174,7 +174,7 @@ describe('VehicleModalService', () => {
     it('should correctly switch from create to edit mode', () => {
       service.openCreate();
       expect(service.formMode()).toBe('create');
-      expect(service.selectedVehicle()).toBe(null);
+      expect(service.selectedVehicle()).toBeNull();
       expect(service.activeModal()).toBe(VehicleModalState.VehicleForm);
 
       service.openEdit(mockVehicle);


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/286)

## Summary

Improve the readability, consistency and maintainability of the vehicle feature test suite by refining assertions, reorganizing tests and applying more specific Jasmine matchers.

The changes keep the existing behavior and coverage while making tests easier to understand, reducing ambiguous assertions and improving the structure of multiple vehicle-related test files.

## What's included

- Improved `VehicleTableComponent` tests by replacing collection length assertions with `toHaveSize` and improving fallback image validations.
- Updated `VehicleTableActionsComponent` tests by using more explicit size assertions for available options.
- Improved `VehicleTablePaginationComponent` tests by replacing button count validations with `toHaveSize`.
- Refactored `VehicleViewComponent` tests by moving the `onFilterChange` test into its own dedicated describe block and replacing length assertions with `toHaveSize`.
- Updated `ManageVehicleUsersModalComponent` tests by replacing generic size checks with more explicit `toHaveSize` assertions.
- Improved `VehicleModalService` tests by replacing `toBe(null)` assertions with the more specific `toBeNull()` matcher.
- Improved empty state tests by refining input assertions and aligning test formatting.
- Applied formatting improvements across vehicle feature test files for better consistency and readability.

## Notes

- No backend changes were required.
- No authentication changes were included.
- No user-facing behavior changes were introduced.
- Changes are limited to frontend test improvements, assertion consistency and test maintainability updates.