### PR TITLE
test(shared/ui): Improve reusable component test structure and readability (#293)

### DIFF
--- a/src/app/shared/ui/buttons/create-button/create-button.spec.ts
+++ b/src/app/shared/ui/buttons/create-button/create-button.spec.ts
@@ -1,9 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CreateButtonComponent } from './create-button';
 
+
 describe('CreateButtonComponent', () => {
   let component: CreateButtonComponent;
   let fixture: ComponentFixture<CreateButtonComponent>;
+
+  const getButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('button');
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/app/shared/ui/buttons/create-button/create-button.spec.ts
+++ b/src/app/shared/ui/buttons/create-button/create-button.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { CreateButtonComponent } from './create-button';
 
+import { CreateButtonComponent } from './create-button';
 
 describe('CreateButtonComponent', () => {
   let component: CreateButtonComponent;
@@ -26,7 +26,7 @@ describe('CreateButtonComponent', () => {
   describe('Template rendering', () => {
 
     it('should render a button element with correct attributes', () => {
-      const button = fixture.nativeElement.querySelector('button');
+      const button = getButton();
 
       expect(button).toBeTruthy();
       expect(button.getAttribute('type')).toBe('button');
@@ -37,25 +37,25 @@ describe('CreateButtonComponent', () => {
       fixture.componentRef.setInput('createText', 'Add vehicle');
       fixture.detectChanges();
 
-      const button = fixture.nativeElement.querySelector('button');
+      const button = getButton();
 
-      expect(button.textContent.trim()).toBe('Add vehicle');
+      expect(button.textContent?.trim()).toBe('Add vehicle');
     });
 
     it('should render empty text when input is null', () => {
       fixture.componentRef.setInput('createText', null);
       fixture.detectChanges();
 
-      const button = fixture.nativeElement.querySelector('button');
+      const button = getButton();
 
-      expect(button.textContent.trim()).toBe('');
+      expect(button.textContent?.trim()).toBe('');
     });
 
     it('should set aria-label from input', () => {
       fixture.componentRef.setInput('createText', 'Add vehicle');
       fixture.detectChanges();
 
-      const button = fixture.nativeElement.querySelector('button');
+      const button = getButton();
 
       expect(button.getAttribute('aria-label')).toBe('Add vehicle');
     });
@@ -75,7 +75,7 @@ describe('CreateButtonComponent', () => {
     it('should emit create when button is clicked', () => {
       spyOn(component.create, 'emit');
 
-      const button = fixture.nativeElement.querySelector('button');
+      const button = getButton();
       button.click();
 
       expect(component.create.emit).toHaveBeenCalled();

--- a/src/app/shared/ui/buttons/dark-mode-toggle/dark-mode-toggle.spec.ts
+++ b/src/app/shared/ui/buttons/dark-mode-toggle/dark-mode-toggle.spec.ts
@@ -45,8 +45,7 @@ describe('DarkModeToggleComponent', () => {
     });
 
     it('should not have active class when isDark is false', () => {
-      mockThemeService.isDark.and.returnValue(false);
-      fixture.detectChanges();
+      setDarkMode(false);
 
       const toggle = getToggle();
 
@@ -54,8 +53,7 @@ describe('DarkModeToggleComponent', () => {
     });
 
     it('should have active class when isDark is true', () => {
-      mockThemeService.isDark.and.returnValue(true);
-      fixture.detectChanges();
+      setDarkMode(true);
 
       const toggle = getToggle();
 
@@ -63,8 +61,7 @@ describe('DarkModeToggleComponent', () => {
     });
 
     it('should set correct aria-checked attribute', () => {
-      mockThemeService.isDark.and.returnValue(true);
-      fixture.detectChanges();
+      setDarkMode(true);
 
       const toggle = getToggle();
 
@@ -72,8 +69,7 @@ describe('DarkModeToggleComponent', () => {
     });
 
     it('should set correct aria-label when dark mode is enabled', () => {
-      mockThemeService.isDark.and.returnValue(true);
-      fixture.detectChanges();
+      setDarkMode(true);
 
       const toggle = getToggle();
 
@@ -81,8 +77,7 @@ describe('DarkModeToggleComponent', () => {
     });
 
     it('should set correct aria-label when dark mode is disabled', () => {
-      mockThemeService.isDark.and.returnValue(false);
-      fixture.detectChanges();
+      setDarkMode(false);
 
       const toggle = getToggle();
 
@@ -90,8 +85,7 @@ describe('DarkModeToggleComponent', () => {
     });
 
     it('should render moon icon when dark mode is active', () => {
-      mockThemeService.isDark.and.returnValue(true);
-      fixture.detectChanges();
+      setDarkMode(true);
 
       const icon = getIcon();
 
@@ -99,8 +93,7 @@ describe('DarkModeToggleComponent', () => {
     });
 
     it('should render sun icon when dark mode is inactive', () => {
-      mockThemeService.isDark.and.returnValue(false);
-      fixture.detectChanges();
+      setDarkMode(false);
 
       const icon = getIcon();
 

--- a/src/app/shared/ui/buttons/dark-mode-toggle/dark-mode-toggle.spec.ts
+++ b/src/app/shared/ui/buttons/dark-mode-toggle/dark-mode-toggle.spec.ts
@@ -8,6 +8,7 @@ describe('DarkModeToggleComponent', () => {
   let mockThemeService: jasmine.SpyObj<ThemeService>;
 
   const getToggle = (): HTMLButtonElement => fixture.nativeElement.querySelector('.toggle');
+  const getIcon = (): HTMLElement => fixture.nativeElement.querySelector('i');
 
   beforeEach(async () => {
     mockThemeService = jasmine.createSpyObj('ThemeService', ['toggle', 'isDark']);

--- a/src/app/shared/ui/buttons/dark-mode-toggle/dark-mode-toggle.spec.ts
+++ b/src/app/shared/ui/buttons/dark-mode-toggle/dark-mode-toggle.spec.ts
@@ -39,7 +39,8 @@ describe('DarkModeToggleComponent', () => {
   describe('Template rendering', () => {
 
     it('should render the toggle container', () => {
-      const toggle = fixture.nativeElement.querySelector('.toggle');
+      const toggle = getToggle();
+
       expect(toggle).toBeTruthy();
     });
 
@@ -47,7 +48,8 @@ describe('DarkModeToggleComponent', () => {
       mockThemeService.isDark.and.returnValue(false);
       fixture.detectChanges();
 
-      const toggle = fixture.nativeElement.querySelector('.toggle');
+      const toggle = getToggle();
+
       expect(toggle.classList.contains('toggle--active')).toBeFalse();
     });
 
@@ -55,7 +57,8 @@ describe('DarkModeToggleComponent', () => {
       mockThemeService.isDark.and.returnValue(true);
       fixture.detectChanges();
 
-      const toggle = fixture.nativeElement.querySelector('.toggle');
+      const toggle = getToggle();
+
       expect(toggle.classList.contains('toggle--active')).toBeTrue();
     });
 
@@ -63,7 +66,8 @@ describe('DarkModeToggleComponent', () => {
       mockThemeService.isDark.and.returnValue(true);
       fixture.detectChanges();
 
-      const toggle = fixture.nativeElement.querySelector('.toggle');
+      const toggle = getToggle();
+
       expect(toggle.getAttribute('aria-checked')).toBe('true');
     });
 
@@ -71,7 +75,8 @@ describe('DarkModeToggleComponent', () => {
       mockThemeService.isDark.and.returnValue(true);
       fixture.detectChanges();
 
-      const toggle = fixture.nativeElement.querySelector('.toggle');
+      const toggle = getToggle();
+
       expect(toggle.getAttribute('aria-label')).toBe('Disable dark mode');
     });
 
@@ -79,7 +84,8 @@ describe('DarkModeToggleComponent', () => {
       mockThemeService.isDark.and.returnValue(false);
       fixture.detectChanges();
 
-      const toggle = fixture.nativeElement.querySelector('.toggle');
+      const toggle = getToggle();
+
       expect(toggle.getAttribute('aria-label')).toBe('Enable dark mode');
     });
 
@@ -88,6 +94,7 @@ describe('DarkModeToggleComponent', () => {
       fixture.detectChanges();
 
       const icon = fixture.nativeElement.querySelector('i');
+
       expect(icon.classList.contains('pi-moon')).toBeTrue();
     });
 
@@ -96,6 +103,7 @@ describe('DarkModeToggleComponent', () => {
       fixture.detectChanges();
 
       const icon = fixture.nativeElement.querySelector('i');
+
       expect(icon.classList.contains('pi-sun')).toBeTrue();
     });
 
@@ -106,7 +114,7 @@ describe('DarkModeToggleComponent', () => {
     it('should call toggle() when clicked', () => {
       spyOn(component, 'toggle');
 
-      const toggle = fixture.nativeElement.querySelector('.toggle');
+      const toggle = getToggle();
       toggle.click();
 
       expect(component.toggle).toHaveBeenCalled();
@@ -119,7 +127,7 @@ describe('DarkModeToggleComponent', () => {
     });
 
     it('should call theme.toggle() when clicking the toggle', () => {
-      const toggle = fixture.nativeElement.querySelector('.toggle');
+      const toggle = getToggle();
       toggle.click();
 
       expect(mockThemeService.toggle).toHaveBeenCalled();
@@ -130,7 +138,8 @@ describe('DarkModeToggleComponent', () => {
   describe('Accessibility', () => {
 
     it('should have role="switch"', () => {
-      const toggle = fixture.nativeElement.querySelector('.toggle');
+      const toggle = getToggle();
+
       expect(toggle.getAttribute('role')).toBe('switch');
     });
 

--- a/src/app/shared/ui/buttons/dark-mode-toggle/dark-mode-toggle.spec.ts
+++ b/src/app/shared/ui/buttons/dark-mode-toggle/dark-mode-toggle.spec.ts
@@ -10,6 +10,11 @@ describe('DarkModeToggleComponent', () => {
   const getToggle = (): HTMLButtonElement => fixture.nativeElement.querySelector('.toggle');
   const getIcon = (): HTMLElement => fixture.nativeElement.querySelector('i');
 
+  const setDarkMode = (isDark: boolean) => {
+    mockThemeService.isDark.and.returnValue(isDark);
+    fixture.detectChanges();
+  };
+
   beforeEach(async () => {
     mockThemeService = jasmine.createSpyObj('ThemeService', ['toggle', 'isDark']);
     mockThemeService.isDark.and.returnValue(false);

--- a/src/app/shared/ui/buttons/dark-mode-toggle/dark-mode-toggle.spec.ts
+++ b/src/app/shared/ui/buttons/dark-mode-toggle/dark-mode-toggle.spec.ts
@@ -46,7 +46,6 @@ describe('DarkModeToggleComponent', () => {
 
     it('should not have active class when isDark is false', () => {
       setDarkMode(false);
-
       const toggle = getToggle();
 
       expect(toggle.classList.contains('toggle--active')).toBeFalse();
@@ -54,7 +53,6 @@ describe('DarkModeToggleComponent', () => {
 
     it('should have active class when isDark is true', () => {
       setDarkMode(true);
-
       const toggle = getToggle();
 
       expect(toggle.classList.contains('toggle--active')).toBeTrue();
@@ -62,7 +60,6 @@ describe('DarkModeToggleComponent', () => {
 
     it('should set correct aria-checked attribute', () => {
       setDarkMode(true);
-
       const toggle = getToggle();
 
       expect(toggle.getAttribute('aria-checked')).toBe('true');
@@ -70,7 +67,6 @@ describe('DarkModeToggleComponent', () => {
 
     it('should set correct aria-label when dark mode is enabled', () => {
       setDarkMode(true);
-
       const toggle = getToggle();
 
       expect(toggle.getAttribute('aria-label')).toBe('Disable dark mode');
@@ -78,7 +74,6 @@ describe('DarkModeToggleComponent', () => {
 
     it('should set correct aria-label when dark mode is disabled', () => {
       setDarkMode(false);
-
       const toggle = getToggle();
 
       expect(toggle.getAttribute('aria-label')).toBe('Enable dark mode');
@@ -86,7 +81,6 @@ describe('DarkModeToggleComponent', () => {
 
     it('should render moon icon when dark mode is active', () => {
       setDarkMode(true);
-
       const icon = getIcon();
 
       expect(icon.classList.contains('pi-moon')).toBeTrue();
@@ -94,7 +88,6 @@ describe('DarkModeToggleComponent', () => {
 
     it('should render sun icon when dark mode is inactive', () => {
       setDarkMode(false);
-
       const icon = getIcon();
 
       expect(icon.classList.contains('pi-sun')).toBeTrue();

--- a/src/app/shared/ui/buttons/dark-mode-toggle/dark-mode-toggle.spec.ts
+++ b/src/app/shared/ui/buttons/dark-mode-toggle/dark-mode-toggle.spec.ts
@@ -93,7 +93,7 @@ describe('DarkModeToggleComponent', () => {
       mockThemeService.isDark.and.returnValue(true);
       fixture.detectChanges();
 
-      const icon = fixture.nativeElement.querySelector('i');
+      const icon = getIcon();
 
       expect(icon.classList.contains('pi-moon')).toBeTrue();
     });
@@ -102,7 +102,7 @@ describe('DarkModeToggleComponent', () => {
       mockThemeService.isDark.and.returnValue(false);
       fixture.detectChanges();
 
-      const icon = fixture.nativeElement.querySelector('i');
+      const icon = getIcon();
 
       expect(icon.classList.contains('pi-sun')).toBeTrue();
     });

--- a/src/app/shared/ui/buttons/dark-mode-toggle/dark-mode-toggle.spec.ts
+++ b/src/app/shared/ui/buttons/dark-mode-toggle/dark-mode-toggle.spec.ts
@@ -7,6 +7,8 @@ describe('DarkModeToggleComponent', () => {
   let fixture: ComponentFixture<DarkModeToggleComponent>;
   let mockThemeService: jasmine.SpyObj<ThemeService>;
 
+  const getToggle = (): HTMLButtonElement => fixture.nativeElement.querySelector('.toggle');
+
   beforeEach(async () => {
     mockThemeService = jasmine.createSpyObj('ThemeService', ['toggle', 'isDark']);
     mockThemeService.isDark.and.returnValue(false);

--- a/src/app/shared/ui/buttons/delete-button/delete-button.spec.ts
+++ b/src/app/shared/ui/buttons/delete-button/delete-button.spec.ts
@@ -25,7 +25,7 @@ describe('DeleteButtonComponent', () => {
   describe('Template rendering', () => {
 
     it('should render button with correct attributes', () => {
-      const button = fixture.nativeElement.querySelector('button');
+      const button = getButton();
 
       expect(button).toBeTruthy();
       expect(button.getAttribute('type')).toBe('button');
@@ -60,7 +60,7 @@ describe('DeleteButtonComponent', () => {
     it('should emit delete when button is clicked', () => {
       const emitSpy = spyOn(component.delete, 'emit');
 
-      const button = fixture.nativeElement.querySelector('button');
+      const button = getButton();
       button.click();
 
       expect(emitSpy).toHaveBeenCalledTimes(1);

--- a/src/app/shared/ui/buttons/delete-button/delete-button.spec.ts
+++ b/src/app/shared/ui/buttons/delete-button/delete-button.spec.ts
@@ -5,6 +5,8 @@ describe('DeleteButtonComponent', () => {
   let component: DeleteButtonComponent;
   let fixture: ComponentFixture<DeleteButtonComponent>;
 
+  const getButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('button');
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [DeleteButtonComponent]

--- a/src/app/shared/ui/buttons/delete-button/delete-button.spec.ts
+++ b/src/app/shared/ui/buttons/delete-button/delete-button.spec.ts
@@ -6,6 +6,7 @@ describe('DeleteButtonComponent', () => {
   let fixture: ComponentFixture<DeleteButtonComponent>;
 
   const getButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('button');
+  const getIcon = (): HTMLElement => fixture.nativeElement.querySelector('i');
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/app/shared/ui/buttons/delete-button/delete-button.spec.ts
+++ b/src/app/shared/ui/buttons/delete-button/delete-button.spec.ts
@@ -54,7 +54,7 @@ describe('DeleteButtonComponent', () => {
 
       component.onClick();
 
-      expect(emitSpy).toHaveBeenCalled();
+      expect(emitSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should emit delete when button is clicked', () => {
@@ -63,7 +63,7 @@ describe('DeleteButtonComponent', () => {
       const button = fixture.nativeElement.querySelector('button');
       button.click();
 
-      expect(emitSpy).toHaveBeenCalled();
+      expect(emitSpy).toHaveBeenCalledTimes(1);
     });
 
   });

--- a/src/app/shared/ui/buttons/delete-button/delete-button.spec.ts
+++ b/src/app/shared/ui/buttons/delete-button/delete-button.spec.ts
@@ -34,14 +34,14 @@ describe('DeleteButtonComponent', () => {
     });
 
     it('should render trash icon', () => {
-      const icon = fixture.nativeElement.querySelector('i');
+      const icon = getIcon();
 
       expect(icon.classList).toContain('pi');
       expect(icon.classList).toContain('pi-trash');
     });
 
     it('should render trash icon with correct class', () => {
-      const icon = fixture.nativeElement.querySelector('i');
+      const icon = getIcon();
 
       expect(icon.classList).toContain('delete-button__icon');
     });

--- a/src/app/shared/ui/buttons/edit-button/edit-button.spec.ts
+++ b/src/app/shared/ui/buttons/edit-button/edit-button.spec.ts
@@ -7,7 +7,7 @@ describe('EditButtonComponent', () => {
 
   const getButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('button');
   const getIcon = (): HTMLElement => fixture.nativeElement.querySelector('i');
-  
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [EditButtonComponent]
@@ -34,7 +34,7 @@ describe('EditButtonComponent', () => {
     });
 
     it('should render edit icon with correct classes', () => {
-      const icon = fixture.nativeElement.querySelector('i');
+      const icon = getIcon();
 
       expect(icon.classList).toContain('pi');
       expect(icon.classList).toContain('pi-pen-to-square');

--- a/src/app/shared/ui/buttons/edit-button/edit-button.spec.ts
+++ b/src/app/shared/ui/buttons/edit-button/edit-button.spec.ts
@@ -6,7 +6,8 @@ describe('EditButtonComponent', () => {
   let fixture: ComponentFixture<EditButtonComponent>;
 
   const getButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('button');
-
+  const getIcon = (): HTMLElement => fixture.nativeElement.querySelector('i');
+  
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [EditButtonComponent]

--- a/src/app/shared/ui/buttons/edit-button/edit-button.spec.ts
+++ b/src/app/shared/ui/buttons/edit-button/edit-button.spec.ts
@@ -6,7 +6,7 @@ describe('EditButtonComponent', () => {
   let fixture: ComponentFixture<EditButtonComponent>;
 
   const getButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('button');
-  
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [EditButtonComponent]
@@ -24,7 +24,7 @@ describe('EditButtonComponent', () => {
   describe('Template rendering', () => {
 
     it('should render button with correct attributes', () => {
-      const button = fixture.nativeElement.querySelector('button');
+      const button = getButton();
 
       expect(button).toBeTruthy();
       expect(button.getAttribute('type')).toBe('button');
@@ -55,7 +55,7 @@ describe('EditButtonComponent', () => {
     it('should emit edit when button is clicked', () => {
       const emitSpy = spyOn(component.edit, 'emit');
 
-      const button = fixture.nativeElement.querySelector('button');
+      const button = getButton();
       button.click();
 
       expect(emitSpy).toHaveBeenCalled();

--- a/src/app/shared/ui/buttons/edit-button/edit-button.spec.ts
+++ b/src/app/shared/ui/buttons/edit-button/edit-button.spec.ts
@@ -50,7 +50,7 @@ describe('EditButtonComponent', () => {
 
       component.onClick();
 
-      expect(emitSpy).toHaveBeenCalled();
+      expect(emitSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should emit edit when button is clicked', () => {
@@ -59,7 +59,7 @@ describe('EditButtonComponent', () => {
       const button = getButton();
       button.click();
 
-      expect(emitSpy).toHaveBeenCalled();
+      expect(emitSpy).toHaveBeenCalledTimes(1);
     });
 
   });

--- a/src/app/shared/ui/buttons/edit-button/edit-button.spec.ts
+++ b/src/app/shared/ui/buttons/edit-button/edit-button.spec.ts
@@ -5,6 +5,8 @@ describe('EditButtonComponent', () => {
   let component: EditButtonComponent;
   let fixture: ComponentFixture<EditButtonComponent>;
 
+  const getButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('button');
+  
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [EditButtonComponent]

--- a/src/app/shared/ui/buttons/user-button/user-button.spec.ts
+++ b/src/app/shared/ui/buttons/user-button/user-button.spec.ts
@@ -8,7 +8,7 @@ describe('UserButtonComponent', () => {
 
   const getButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('button');
   const getIcon = (): HTMLElement => fixture.nativeElement.querySelector('i');
-  
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [UserButtonComponent]
@@ -35,7 +35,7 @@ describe('UserButtonComponent', () => {
     });
 
     it('should render user icon with correct classes', () => {
-      const icon = fixture.nativeElement.querySelector('i');
+      const icon = getIcon();
 
       expect(icon.classList).toContain('fa-solid');
       expect(icon.classList).toContain('fa-user-group');

--- a/src/app/shared/ui/buttons/user-button/user-button.spec.ts
+++ b/src/app/shared/ui/buttons/user-button/user-button.spec.ts
@@ -6,6 +6,8 @@ describe('UserButtonComponent', () => {
   let component: UserButtonComponent;
   let fixture: ComponentFixture<UserButtonComponent>;
 
+  const getButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('button');
+  
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [UserButtonComponent]

--- a/src/app/shared/ui/buttons/user-button/user-button.spec.ts
+++ b/src/app/shared/ui/buttons/user-button/user-button.spec.ts
@@ -7,7 +7,7 @@ describe('UserButtonComponent', () => {
   let fixture: ComponentFixture<UserButtonComponent>;
 
   const getButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('button');
-  
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [UserButtonComponent]
@@ -26,7 +26,7 @@ describe('UserButtonComponent', () => {
   describe('Template rendering', () => {
 
     it('should render button with correct attributes', () => {
-      const button = fixture.nativeElement.querySelector('button');
+      const button = getButton();
 
       expect(button).toBeTruthy();
       expect(button.getAttribute('type')).toBe('button');
@@ -57,7 +57,7 @@ describe('UserButtonComponent', () => {
     it('should emit user when button is clicked', () => {
       const emitSpy = spyOn(component.user, 'emit');
 
-      const button = fixture.nativeElement.querySelector('button');
+      const button = getButton();
       button.click();
 
       expect(emitSpy).toHaveBeenCalled();

--- a/src/app/shared/ui/buttons/user-button/user-button.spec.ts
+++ b/src/app/shared/ui/buttons/user-button/user-button.spec.ts
@@ -7,7 +7,8 @@ describe('UserButtonComponent', () => {
   let fixture: ComponentFixture<UserButtonComponent>;
 
   const getButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('button');
-
+  const getIcon = (): HTMLElement => fixture.nativeElement.querySelector('i');
+  
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [UserButtonComponent]

--- a/src/app/shared/ui/modals/confirm-modal/confirm-modal.spec.ts
+++ b/src/app/shared/ui/modals/confirm-modal/confirm-modal.spec.ts
@@ -9,7 +9,8 @@ describe('ConfirmModalComponent', () => {
   const getForm = (): HTMLFormElement => fixture.nativeElement.querySelector('.modal__form');
 
   const getConfirmButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('.modal__button--confirm');
-
+  const getCancelButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('.modal__button--cancel');
+  
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ConfirmModalComponent]

--- a/src/app/shared/ui/modals/confirm-modal/confirm-modal.spec.ts
+++ b/src/app/shared/ui/modals/confirm-modal/confirm-modal.spec.ts
@@ -8,6 +8,8 @@ describe('ConfirmModalComponent', () => {
   const getModal = (): HTMLDialogElement => fixture.nativeElement.querySelector('.modal__backdrop');
   const getForm = (): HTMLFormElement => fixture.nativeElement.querySelector('.modal__form');
 
+  const getConfirmButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('.modal__button--confirm');
+  
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ConfirmModalComponent]

--- a/src/app/shared/ui/modals/confirm-modal/confirm-modal.spec.ts
+++ b/src/app/shared/ui/modals/confirm-modal/confirm-modal.spec.ts
@@ -7,7 +7,7 @@ describe('ConfirmModalComponent', () => {
 
   const getModal = (): HTMLDialogElement => fixture.nativeElement.querySelector('.modal__backdrop');
   const getForm = (): HTMLFormElement => fixture.nativeElement.querySelector('.modal__form');
-  
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ConfirmModalComponent]
@@ -77,7 +77,7 @@ describe('ConfirmModalComponent', () => {
     it('should NOT call onCancel when clicking inside modal form', () => {
       const spyCancel = spyOn(component, 'onCancel');
 
-      const modalForm = fixture.nativeElement.querySelector('.modal__form');
+      const modalForm = getForm();
       modalForm.click();
 
       expect(spyCancel).not.toHaveBeenCalled();

--- a/src/app/shared/ui/modals/confirm-modal/confirm-modal.spec.ts
+++ b/src/app/shared/ui/modals/confirm-modal/confirm-modal.spec.ts
@@ -62,7 +62,7 @@ describe('ConfirmModalComponent', () => {
     it('should call onCancel when Cancel button is clicked', () => {
       const spyCancel = spyOn(component, 'onCancel');
 
-      const cancelButton = fixture.nativeElement.querySelector('.modal__button--cancel');
+      const cancelButton = getCancelButton();
       cancelButton.click();
 
       expect(spyCancel).toHaveBeenCalled();

--- a/src/app/shared/ui/modals/confirm-modal/confirm-modal.spec.ts
+++ b/src/app/shared/ui/modals/confirm-modal/confirm-modal.spec.ts
@@ -6,7 +6,7 @@ describe('ConfirmModalComponent', () => {
   let fixture: ComponentFixture<ConfirmModalComponent>;
 
   const getModal = (): HTMLDialogElement => fixture.nativeElement.querySelector('.modal__backdrop');
-  
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ConfirmModalComponent]
@@ -36,11 +36,13 @@ describe('ConfirmModalComponent', () => {
 
     it('should render the title input in the modal', () => {
       const title: HTMLElement = fixture.nativeElement.querySelector('#confirm-modal__modal-title');
+
       expect(title.textContent?.trim()).toBe(component.title());
     });
 
     it('should render the message input in the modal', () => {
       const message: HTMLElement = fixture.nativeElement.querySelector('#confirm-modal__modal-message');
+
       expect(message.textContent?.trim()).toBe(component.message());
     });
 
@@ -65,8 +67,8 @@ describe('ConfirmModalComponent', () => {
     it('should call onCancel when clicking on modal background', () => {
       const spyCancel = spyOn(component, 'onCancel');
 
-      const modalDiv = fixture.nativeElement.querySelector('.modal__backdrop');
-      modalDiv.click();
+      const modal = getModal();
+      modal.click();
 
       expect(spyCancel).toHaveBeenCalled();
     });
@@ -86,6 +88,7 @@ describe('ConfirmModalComponent', () => {
 
     it('should emit confirm event when onConfirm is called', () => {
       const spyConfirm = spyOn(component.confirm, 'emit');
+
       component.onConfirm();
 
       expect(spyConfirm).toHaveBeenCalled();
@@ -106,6 +109,7 @@ describe('ConfirmModalComponent', () => {
 
     it('should emit cancel event when onCancel is called', () => {
       const spyCancel = spyOn(component.cancel, 'emit');
+
       component.onCancel();
 
       expect(spyCancel).toHaveBeenCalled();
@@ -114,8 +118,8 @@ describe('ConfirmModalComponent', () => {
     it('should emit cancel event when clicking on modal background', () => {
       const spyCancel = spyOn(component.cancel, 'emit');
 
-      const modalDiv = fixture.nativeElement.querySelector('.modal__backdrop');
-      modalDiv.click();
+      const modal = getModal();
+      modal.click();
 
       expect(spyCancel).toHaveBeenCalled();
     });
@@ -125,7 +129,7 @@ describe('ConfirmModalComponent', () => {
   describe('Accessibility attributes', () => {
 
     it('should have aria attributes on the dialog', () => {
-      const modal: HTMLElement = fixture.nativeElement.querySelector('.modal__backdrop');
+      const modal = getModal();
 
       expect(modal.getAttribute('aria-modal')).toBe('true');
       expect(modal.getAttribute('aria-labelledby')).toBe('confirm-modal__modal-title');
@@ -141,6 +145,7 @@ describe('ConfirmModalComponent', () => {
       fixture.detectChanges();
 
       const title: HTMLElement = fixture.nativeElement.querySelector('#confirm-modal__modal-title');
+
       expect(title.textContent?.trim()).toBe('Delete vehicle?');
     });
 
@@ -149,6 +154,7 @@ describe('ConfirmModalComponent', () => {
       fixture.detectChanges();
 
       const message: HTMLElement = fixture.nativeElement.querySelector('#confirm-modal__modal-message');
+
       expect(message.textContent?.trim()).toBe('This vehicle will be permanently removed');
     });
 
@@ -159,7 +165,7 @@ describe('ConfirmModalComponent', () => {
     it('should call onCancel when Escape key is pressed', () => {
       const spyCancel = spyOn(component, 'onCancel');
 
-      const modal: HTMLElement = fixture.nativeElement.querySelector('.modal__backdrop');
+      const modal = getModal();
       modal.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
 
       expect(spyCancel).toHaveBeenCalled();

--- a/src/app/shared/ui/modals/confirm-modal/confirm-modal.spec.ts
+++ b/src/app/shared/ui/modals/confirm-modal/confirm-modal.spec.ts
@@ -5,6 +5,8 @@ describe('ConfirmModalComponent', () => {
   let component: ConfirmModalComponent;
   let fixture: ComponentFixture<ConfirmModalComponent>;
 
+  const getModal = (): HTMLDialogElement => fixture.nativeElement.querySelector('.modal__backdrop');
+  
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ConfirmModalComponent]

--- a/src/app/shared/ui/modals/confirm-modal/confirm-modal.spec.ts
+++ b/src/app/shared/ui/modals/confirm-modal/confirm-modal.spec.ts
@@ -9,7 +9,7 @@ describe('ConfirmModalComponent', () => {
   const getForm = (): HTMLFormElement => fixture.nativeElement.querySelector('.modal__form');
 
   const getConfirmButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('.modal__button--confirm');
-  
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ConfirmModalComponent]
@@ -52,7 +52,7 @@ describe('ConfirmModalComponent', () => {
     it('should call onConfirm when Confirm button is clicked', () => {
       const spyConfirm = spyOn(component, 'onConfirm');
 
-      const confirmButton = fixture.nativeElement.querySelector('.modal__button--confirm');
+      const confirmButton = getConfirmButton();
       confirmButton.click();
 
       expect(spyConfirm).toHaveBeenCalled();
@@ -100,7 +100,7 @@ describe('ConfirmModalComponent', () => {
     it('should emit confirm event when Confirm button is clicked', () => {
       const spyConfirm = spyOn(component.confirm, 'emit');
 
-      const confirmButton = fixture.nativeElement.querySelector('.modal__button--confirm');
+      const confirmButton = getConfirmButton();
       confirmButton.click();
 
       expect(spyConfirm).toHaveBeenCalled();

--- a/src/app/shared/ui/modals/confirm-modal/confirm-modal.spec.ts
+++ b/src/app/shared/ui/modals/confirm-modal/confirm-modal.spec.ts
@@ -6,7 +6,8 @@ describe('ConfirmModalComponent', () => {
   let fixture: ComponentFixture<ConfirmModalComponent>;
 
   const getModal = (): HTMLDialogElement => fixture.nativeElement.querySelector('.modal__backdrop');
-
+  const getForm = (): HTMLFormElement => fixture.nativeElement.querySelector('.modal__form');
+  
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ConfirmModalComponent]


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/293)

## Summary

Improve the readability and maintainability of reusable component tests by introducing shared DOM query helpers, reducing repeated selectors and standardizing test interaction patterns.

The changes keep the existing behavior and coverage while making component tests easier to read, update and extend.

## What's included

- Added reusable DOM helpers in button component tests to avoid repeated element queries.
- Improved test readability by introducing shared selectors for buttons and icons.
- Refactored modal component tests with reusable helpers for modal, form and action buttons.
- Improved consistency across component interaction tests.
- Maintained existing coverage for rendering, accessibility attributes, inputs and output events.
- Kept component behavior unchanged while improving test structure.

## Notes

- No component behavior changes were introduced.
- No UI changes were introduced.
- No service or backend changes were required.
- Changes are limited to frontend test maintainability and code quality improvements.