### PR TITLE
test(layout): Improve test structure and readability across core layout components (#295)

### DIFF
--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -14,7 +14,8 @@ describe('AccountDrawerComponent', () => {
   const getAside = (): HTMLElement => fixture.nativeElement.querySelector('aside.drawer');
   const getCloseButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('.drawer__close');
   const getMenuItems = (): NodeListOf<HTMLButtonElement> => fixture.nativeElement.querySelectorAll('.drawer__section:first-of-type .drawer__item');
-
+  const getDarkModeToggle = (): HTMLElement => fixture.nativeElement.querySelector('app-dark-mode-toggle');
+  
   beforeEach(async () => {
     mockThemeService.isDark.and.returnValue(false);
 

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -14,7 +14,7 @@ describe('AccountDrawerComponent', () => {
   const getAside = (): HTMLElement => fixture.nativeElement.querySelector('aside.drawer');
   const getCloseButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('.drawer__close');
   const getMenuItems = (): NodeListOf<HTMLButtonElement> => fixture.nativeElement.querySelectorAll('.drawer__section:first-of-type .drawer__item');
-  
+
   beforeEach(async () => {
     mockThemeService.isDark.and.returnValue(false);
 
@@ -63,7 +63,7 @@ describe('AccountDrawerComponent', () => {
     });
 
     it('should render all menu items', () => {
-      const items = fixture.nativeElement.querySelectorAll('.drawer__section:first-of-type .drawer__item');
+      const items = getMenuItems();
 
       expect(items).toHaveSize(4);
       expect(items[0].textContent).toContain(component.drawerMsg.items.editProfile);

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -8,6 +8,7 @@ describe('AccountDrawerComponent', () => {
   let fixture: ComponentFixture<AccountDrawerComponent>;
 
   const mockThemeService = jasmine.createSpyObj('ThemeService', ['toggle', 'isDark']);
+  const getTitle = (): HTMLElement => fixture.nativeElement.querySelector('.drawer__title');
 
   beforeEach(async () => {
     mockThemeService.isDark.and.returnValue(false);

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -11,6 +11,7 @@ describe('AccountDrawerComponent', () => {
 
   const getTitle = (): HTMLElement => fixture.nativeElement.querySelector('.drawer__title');
   const getBackdrop = (): HTMLElement => fixture.nativeElement.querySelector('.drawer__backdrop');
+  const getAside = (): HTMLElement => fixture.nativeElement.querySelector('aside.drawer');
 
   beforeEach(async () => {
     mockThemeService.isDark.and.returnValue(false);

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -8,7 +8,9 @@ describe('AccountDrawerComponent', () => {
   let fixture: ComponentFixture<AccountDrawerComponent>;
 
   const mockThemeService = jasmine.createSpyObj('ThemeService', ['toggle', 'isDark']);
+
   const getTitle = (): HTMLElement => fixture.nativeElement.querySelector('.drawer__title');
+  const getBackdrop = (): HTMLElement => fixture.nativeElement.querySelector('.drawer__backdrop');
 
   beforeEach(async () => {
     mockThemeService.isDark.and.returnValue(false);

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -56,7 +56,7 @@ describe('AccountDrawerComponent', () => {
     });
 
     it('should render the close button', () => {
-      const button = fixture.nativeElement.querySelector('.drawer__close');
+      const button = getCloseButton();
 
       expect(button).toBeTruthy();
     });
@@ -105,7 +105,7 @@ describe('AccountDrawerComponent', () => {
 
     it('should emit close when close button is clicked', () => {
       spyOn(component.close, 'emit');
-      const button = fixture.nativeElement.querySelector('.drawer__close');
+      const button = getCloseButton();
       button.click();
 
       expect(component.close.emit).toHaveBeenCalled();
@@ -160,7 +160,7 @@ describe('AccountDrawerComponent', () => {
     });
 
     it('should have aria-label on the close button', () => {
-      const button = fixture.nativeElement.querySelector('.drawer__close');
+      const button = getCloseButton();
 
       expect(button.getAttribute('aria-label')).toBe(component.drawerMsg.aria.closeButton);
     });

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -12,6 +12,7 @@ describe('AccountDrawerComponent', () => {
   const getTitle = (): HTMLElement => fixture.nativeElement.querySelector('.drawer__title');
   const getBackdrop = (): HTMLElement => fixture.nativeElement.querySelector('.drawer__backdrop');
   const getAside = (): HTMLElement => fixture.nativeElement.querySelector('aside.drawer');
+  const getCloseButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('.drawer__close');
 
   beforeEach(async () => {
     mockThemeService.isDark.and.returnValue(false);

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -15,6 +15,7 @@ describe('AccountDrawerComponent', () => {
   const getCloseButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('.drawer__close');
   const getMenuItems = (): NodeListOf<HTMLButtonElement> => fixture.nativeElement.querySelectorAll('.drawer__section:first-of-type .drawer__item');
   const getDarkModeToggle = (): HTMLElement => fixture.nativeElement.querySelector('app-dark-mode-toggle');
+  const getLogoutButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('.drawer__item--danger');
   
   beforeEach(async () => {
     mockThemeService.isDark.and.returnValue(false);

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -59,7 +59,7 @@ describe('AccountDrawerComponent', () => {
     it('should render all menu items', () => {
       const items = fixture.nativeElement.querySelectorAll('.drawer__section:first-of-type .drawer__item');
 
-      expect(items.length).toBe(4);
+      expect(items).toHaveSize(4);
       expect(items[0].textContent).toContain(component.drawerMsg.items.editProfile);
       expect(items[1].textContent).toContain(component.drawerMsg.items.settings);
       expect(items[2].textContent).toContain(component.drawerMsg.items.language);

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -41,7 +41,7 @@ describe('AccountDrawerComponent', () => {
     });
 
     it('should render the aside with role dialog', () => {
-      const aside = fixture.nativeElement.querySelector('aside.drawer');
+      const aside = getAside();
 
       expect(aside).toBeTruthy();
       expect(aside.getAttribute('role')).toBe('dialog');
@@ -153,7 +153,7 @@ describe('AccountDrawerComponent', () => {
     });
 
     it('should have aria-label on the aside', () => {
-      const aside = fixture.nativeElement.querySelector('aside.drawer');
+      const aside = getAside();
 
       expect(aside.getAttribute('aria-label')).toBe(component.drawerMsg.aria.drawer);
     });

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -34,7 +34,7 @@ describe('AccountDrawerComponent', () => {
   describe('Template rendering', () => {
 
     it('should render the backdrop', () => {
-      const backdrop = fixture.nativeElement.querySelector('.drawer__backdrop');
+      const backdrop = getBackdrop();
 
       expect(backdrop).toBeTruthy();
     });
@@ -95,7 +95,7 @@ describe('AccountDrawerComponent', () => {
 
     it('should emit close when backdrop is clicked', () => {
       spyOn(component.close, 'emit');
-      const backdrop = fixture.nativeElement.querySelector('.drawer__backdrop');
+      const backdrop = getBackdrop();
       backdrop.click();
 
       expect(component.close.emit).toHaveBeenCalled();
@@ -146,7 +146,7 @@ describe('AccountDrawerComponent', () => {
   describe('Accessibility', () => {
 
     it('should have aria-hidden on backdrop', () => {
-      const backdrop = fixture.nativeElement.querySelector('.drawer__backdrop');
+      const backdrop = getBackdrop()
 
       expect(backdrop.getAttribute('aria-hidden')).toBe('true');
     });

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -13,7 +13,8 @@ describe('AccountDrawerComponent', () => {
   const getBackdrop = (): HTMLElement => fixture.nativeElement.querySelector('.drawer__backdrop');
   const getAside = (): HTMLElement => fixture.nativeElement.querySelector('aside.drawer');
   const getCloseButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('.drawer__close');
-
+  const getMenuItems = (): NodeListOf<HTMLButtonElement> => fixture.nativeElement.querySelectorAll('.drawer__section:first-of-type .drawer__item');
+  
   beforeEach(async () => {
     mockThemeService.isDark.and.returnValue(false);
 

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -74,7 +74,7 @@ describe('AccountDrawerComponent', () => {
     });
 
     it('should render the dark mode toggle', () => {
-      const toggle = fixture.nativeElement.querySelector('app-dark-mode-toggle');
+      const toggle = getDarkModeToggle();
 
       expect(toggle).toBeTruthy();
     });

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -45,7 +45,7 @@ describe('AccountDrawerComponent', () => {
     });
 
     it('should render the drawer title', () => {
-      const title = fixture.nativeElement.querySelector('.drawer__title');
+      const title = getTitle();
 
       expect(title).toBeTruthy();
       expect(title.textContent.trim()).toBe(component.drawerMsg.title);

--- a/src/app/core/layout/account-drawer/account-drawer.spec.ts
+++ b/src/app/core/layout/account-drawer/account-drawer.spec.ts
@@ -16,7 +16,7 @@ describe('AccountDrawerComponent', () => {
   const getMenuItems = (): NodeListOf<HTMLButtonElement> => fixture.nativeElement.querySelectorAll('.drawer__section:first-of-type .drawer__item');
   const getDarkModeToggle = (): HTMLElement => fixture.nativeElement.querySelector('app-dark-mode-toggle');
   const getLogoutButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('.drawer__item--danger');
-  
+
   beforeEach(async () => {
     mockThemeService.isDark.and.returnValue(false);
 
@@ -81,7 +81,7 @@ describe('AccountDrawerComponent', () => {
     });
 
     it('should render the logout button', () => {
-      const button = fixture.nativeElement.querySelector('.drawer__item--danger');
+      const button = getLogoutButton();
 
       expect(button).toBeTruthy();
       expect(button.textContent).toContain(component.drawerMsg.buttons.logout);
@@ -127,7 +127,8 @@ describe('AccountDrawerComponent', () => {
 
     it('should emit logout when logout button is clicked', () => {
       spyOn(component.logout, 'emit');
-      const logoutButton = fixture.nativeElement.querySelector('.drawer__item--danger');
+
+      const logoutButton = getLogoutButton();
       logoutButton.click();
 
       expect(component.logout.emit).toHaveBeenCalled();

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -34,7 +34,7 @@ describe('AuthActionsComponent', () => {
   const getRegisterButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('[data-test="registerButton"]');
   const getDrawer = (): HTMLElement => fixture.nativeElement.querySelector('app-account-drawer');
   const getDrawerDebugElement = () => fixture.debugElement.query(sel => sel.name === 'app-account-drawer');
-  
+
   const getRouter = (): Router => TestBed.inject(Router);
   const getAuthService = (): MockAuthService => TestBed.inject(AuthService) as unknown as MockAuthService;
 
@@ -214,10 +214,8 @@ describe('AuthActionsComponent', () => {
 
       spyOn(component, 'onLogout');
 
-      const drawer = fixture.debugElement.query(
-        sel => sel.name === 'app-account-drawer'
-      );
-      drawer.triggerEventHandler('logout');
+      const drawerDebugElement = getDrawerDebugElement();
+      drawerDebugElement.triggerEventHandler('logout');
 
       expect(component.onLogout).toHaveBeenCalled();
     });
@@ -231,8 +229,8 @@ describe('AuthActionsComponent', () => {
       component.isDrawerOpen.set(true);
       fixture.detectChanges();
 
-      const drawer = fixture.debugElement.query(sel => sel.name === 'app-account-drawer');
-      drawer.triggerEventHandler('close');
+      const drawerDebugElement = getDrawerDebugElement();
+      drawerDebugElement.triggerEventHandler('close');
 
       expect(component.isDrawerOpen()).toBeFalse();
     });

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -93,7 +93,7 @@ describe('AuthActionsComponent', () => {
       component.isLogged = signal(false);
       fixture.detectChanges();
 
-      const loginButton = fixture.nativeElement.querySelector('[data-test="loginButton"]');
+      const loginButton = getLoginButton();
       const registerButton = fixture.nativeElement.querySelector('[data-test="registerButton"]');
 
       expect(loginButton).toBeTruthy();
@@ -124,7 +124,7 @@ describe('AuthActionsComponent', () => {
       component.isLogged = signal(false);
       fixture.detectChanges();
 
-      const loginButton = fixture.nativeElement.querySelector('[data-test="loginButton"]');
+      const loginButton = getLoginButton();
       loginButton.click();
 
       expect(navigateByUrlSpy.calls.mostRecent().args[0].toString()).toBe('/auth/login');
@@ -285,18 +285,18 @@ describe('AuthActionsComponent', () => {
       component.isLogged = signal(true);
       fixture.detectChanges();
 
-      const button = getSettingsButton();
+      const settingsButton = getSettingsButton();
 
-      expect(button.getAttribute('aria-label')).toBe(component.drawerMsg.aria.openButton);
+      expect(settingsButton.getAttribute('aria-label')).toBe(component.drawerMsg.aria.openButton);
     });
 
     it('should have aria-label on login button', () => {
       component.isLogged = signal(false);
       fixture.detectChanges();
 
-      const button = fixture.nativeElement.querySelector('[data-test="loginButton"]');
+      const loginButton = getLoginButton();
 
-      expect(button.getAttribute('aria-label')).toBe(component.authActionsMsg.aria.login);
+      expect(loginButton.getAttribute('aria-label')).toBe(component.authActionsMsg.aria.login);
     });
 
     it('should have aria-label on register button', () => {

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -32,6 +32,7 @@ describe('AuthActionsComponent', () => {
   const getSettingsButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('.navbar__auth-button');
   const getLoginButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('[data-test="loginButton"]');
   const getRegisterButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('[data-test="registerButton"]');
+  const getDrawer = (): HTMLElement => fixture.nativeElement.querySelector('app-account-drawer');
   
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -35,9 +35,6 @@ describe('AuthActionsComponent', () => {
   const getDrawer = (): HTMLElement => fixture.nativeElement.querySelector('app-account-drawer');
   const getDrawerDebugElement = () => fixture.debugElement.query(sel => sel.name === 'app-account-drawer');
 
-  const getRouter = (): Router => TestBed.inject(Router);
-  const getAuthService = (): MockAuthService => TestBed.inject(AuthService) as unknown as MockAuthService;
-
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AuthActionsComponent],

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -94,7 +94,7 @@ describe('AuthActionsComponent', () => {
       fixture.detectChanges();
 
       const loginButton = getLoginButton();
-      const registerButton = fixture.nativeElement.querySelector('[data-test="registerButton"]');
+      const registerButton = getRegisterButton();
 
       expect(loginButton).toBeTruthy();
       expect(registerButton).toBeTruthy();
@@ -129,7 +129,7 @@ describe('AuthActionsComponent', () => {
 
       expect(navigateByUrlSpy.calls.mostRecent().args[0].toString()).toBe('/auth/login');
 
-      const registerButton = fixture.nativeElement.querySelector('[data-test="registerButton"]');
+      const registerButton = getRegisterButton();
       registerButton.click();
 
       expect(navigateByUrlSpy.calls.mostRecent().args[0].toString()).toBe('/auth/register');
@@ -303,9 +303,9 @@ describe('AuthActionsComponent', () => {
       component.isLogged = signal(false);
       fixture.detectChanges();
 
-      const button = fixture.nativeElement.querySelector('[data-test="registerButton"]');
+      const registerButton = getRegisterButton();
 
-      expect(button.getAttribute('aria-label')).toBe(component.authActionsMsg.aria.register);
+      expect(registerButton.getAttribute('aria-label')).toBe(component.authActionsMsg.aria.register);
     });
 
   });

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -34,7 +34,7 @@ describe('AuthActionsComponent', () => {
   const getRegisterButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('[data-test="registerButton"]');
   const getDrawer = (): HTMLElement => fixture.nativeElement.querySelector('app-account-drawer');
   const getDrawerDebugElement = () => fixture.debugElement.query(sel => sel.name === 'app-account-drawer');
-
+  
   const getRouter = (): Router => TestBed.inject(Router);
   const getAuthService = (): MockAuthService => TestBed.inject(AuthService) as unknown as MockAuthService;
 
@@ -104,7 +104,7 @@ describe('AuthActionsComponent', () => {
       component.isLogged = signal(true);
       fixture.detectChanges();
 
-      const drawer = fixture.nativeElement.querySelector('app-account-drawer');
+      const drawer = getDrawer();
       expect(drawer).toBeFalsy();
     });
 
@@ -113,7 +113,7 @@ describe('AuthActionsComponent', () => {
       component.isDrawerOpen.set(true);
       fixture.detectChanges();
 
-      const drawer = fixture.nativeElement.querySelector('app-account-drawer');
+      const drawer = getDrawer();
       expect(drawer).toBeTruthy();
     });
 
@@ -165,7 +165,7 @@ describe('AuthActionsComponent', () => {
       component.closeDrawer();
       fixture.detectChanges();
 
-      const drawer = fixture.nativeElement.querySelector('app-account-drawer');
+      const drawer = getDrawer();
       expect(drawer).toBeFalsy();
     });
 

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -34,6 +34,8 @@ describe('AuthActionsComponent', () => {
   const getRegisterButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('[data-test="registerButton"]');
   const getDrawer = (): HTMLElement => fixture.nativeElement.querySelector('app-account-drawer');
   const getDrawerDebugElement = () => fixture.debugElement.query(sel => sel.name === 'app-account-drawer');
+
+  const getRouter = (): Router => TestBed.inject(Router);
   
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -30,6 +30,7 @@ describe('AuthActionsComponent', () => {
   let authService: MockAuthService;
 
   const getSettingsButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('.navbar__auth-button');
+  const getLoginButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('[data-test="loginButton"]');
   
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -36,7 +36,8 @@ describe('AuthActionsComponent', () => {
   const getDrawerDebugElement = () => fixture.debugElement.query(sel => sel.name === 'app-account-drawer');
 
   const getRouter = (): Router => TestBed.inject(Router);
-  
+  const getAuthService = (): MockAuthService => TestBed.inject(AuthService) as unknown as MockAuthService;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AuthActionsComponent],

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -85,7 +85,7 @@ describe('AuthActionsComponent', () => {
       component.isLogged = signal(true);
       fixture.detectChanges();
 
-      const settingsButton = fixture.nativeElement.querySelector('.navbar__auth-button');
+      const settingsButton = getSettingsButton();
       expect(settingsButton).toBeTruthy();
     });
 
@@ -143,7 +143,7 @@ describe('AuthActionsComponent', () => {
       component.isLogged = signal(true);
       fixture.detectChanges();
 
-      const settingsButton = fixture.nativeElement.querySelector('.navbar__auth-button');
+      const settingsButton = getSettingsButton();
       settingsButton.click();
       fixture.detectChanges();
 
@@ -272,7 +272,7 @@ describe('AuthActionsComponent', () => {
       component.isLogged = signal(true);
       fixture.detectChanges();
 
-      const settingsButton = fixture.nativeElement.querySelector('.navbar__auth-button');
+      const settingsButton = getSettingsButton();
 
       expect(settingsButton).toBeTruthy();
     });
@@ -285,7 +285,7 @@ describe('AuthActionsComponent', () => {
       component.isLogged = signal(true);
       fixture.detectChanges();
 
-      const button = fixture.nativeElement.querySelector('.navbar__auth-button');
+      const button = getSettingsButton();
 
       expect(button.getAttribute('aria-label')).toBe(component.drawerMsg.aria.openButton);
     });

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -29,6 +29,8 @@ describe('AuthActionsComponent', () => {
   let fixture: ComponentFixture<AuthActionsComponent>;
   let authService: MockAuthService;
 
+  const getSettingsButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('.navbar__auth-button');
+  
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AuthActionsComponent],

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -33,6 +33,7 @@ describe('AuthActionsComponent', () => {
   const getLoginButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('[data-test="loginButton"]');
   const getRegisterButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('[data-test="registerButton"]');
   const getDrawer = (): HTMLElement => fixture.nativeElement.querySelector('app-account-drawer');
+  const getDrawerDebugElement = () => fixture.debugElement.query(sel => sel.name === 'app-account-drawer');
   
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/app/core/layout/auth-actions/auth-actions.spec.ts
+++ b/src/app/core/layout/auth-actions/auth-actions.spec.ts
@@ -31,6 +31,7 @@ describe('AuthActionsComponent', () => {
 
   const getSettingsButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('.navbar__auth-button');
   const getLoginButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('[data-test="loginButton"]');
+  const getRegisterButton = (): HTMLButtonElement => fixture.nativeElement.querySelector('[data-test="registerButton"]');
   
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/app/core/layout/header/header.spec.ts
+++ b/src/app/core/layout/header/header.spec.ts
@@ -13,6 +13,8 @@ describe('HeaderComponent', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
 
+  const getHeader = (): HTMLElement => fixture.nativeElement.querySelector('header');
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [

--- a/src/app/core/layout/header/header.spec.ts
+++ b/src/app/core/layout/header/header.spec.ts
@@ -13,7 +13,7 @@ describe('HeaderComponent', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
 
-  const getHeader = (): HTMLElement => fixture.nativeElement.querySelector('header');
+  const getHeader = (): HTMLElement => fixture.nativeElement.querySelector('header')!;
   const getNavigation = (): HTMLElement => fixture.nativeElement.querySelector('app-navigation')!;
   const getAuthActions = (): HTMLElement => fixture.nativeElement.querySelector('app-auth-actions')!;
 

--- a/src/app/core/layout/header/header.spec.ts
+++ b/src/app/core/layout/header/header.spec.ts
@@ -52,7 +52,7 @@ describe('HeaderComponent', () => {
     });
 
     it('should render NavigationComponent', () => {
-      const navigation = fixture.nativeElement.querySelector('app-navigation');
+      const navigation = getNavigation();
       expect(navigation).toBeTruthy();
     });
 
@@ -67,7 +67,7 @@ describe('HeaderComponent', () => {
 
     it('should contain app-navigation before app-auth-actions', () => {
       const header = getHeader();
-      const navigation = header.querySelector('app-navigation')!;
+      const navigation = getNavigation()!;
       const authActions = header.querySelector('app-auth-actions')!;
 
       expect(navigation).toBeTruthy();

--- a/src/app/core/layout/header/header.spec.ts
+++ b/src/app/core/layout/header/header.spec.ts
@@ -43,7 +43,7 @@ describe('HeaderComponent', () => {
   describe('Template rendering', () => {
 
     it('should render the header element with correct role and class', () => {
-      const header = fixture.nativeElement.querySelector('header');
+      const header = getHeader();
 
       expect(header).toBeTruthy();
       expect(header.getAttribute('role')).toBe('banner');
@@ -65,7 +65,7 @@ describe('HeaderComponent', () => {
   describe('Layout structure', () => {
 
     it('should contain app-navigation before app-auth-actions', () => {
-      const header = fixture.nativeElement.querySelector('header');
+      const header = getHeader();
       const navigation = header.querySelector('app-navigation');
       const authActions = header.querySelector('app-auth-actions');
 

--- a/src/app/core/layout/header/header.spec.ts
+++ b/src/app/core/layout/header/header.spec.ts
@@ -66,8 +66,8 @@ describe('HeaderComponent', () => {
 
     it('should contain app-navigation before app-auth-actions', () => {
       const header = getHeader();
-      const navigation = header.querySelector('app-navigation');
-      const authActions = header.querySelector('app-auth-actions');
+      const navigation = header.querySelector('app-navigation')!;
+      const authActions = header.querySelector('app-auth-actions')!;
 
       expect(navigation).toBeTruthy();
       expect(authActions).toBeTruthy();

--- a/src/app/core/layout/header/header.spec.ts
+++ b/src/app/core/layout/header/header.spec.ts
@@ -19,15 +19,12 @@ describe('HeaderComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        HeaderComponent,
-      ],
+      imports: [HeaderComponent],
       providers: [
         provideRouter([]),
         { provide: AuthService, useClass: MockAuthService},
       ]
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(HeaderComponent);
     component = fixture.componentInstance;
@@ -54,11 +51,13 @@ describe('HeaderComponent', () => {
 
     it('should render NavigationComponent', () => {
       const navigation = getNavigation();
+
       expect(navigation).toBeTruthy();
     });
 
     it('should render AuthActionsComponent', () => {
       const authActions = getAuthActions();
+      
       expect(authActions).toBeTruthy();
     });
 

--- a/src/app/core/layout/header/header.spec.ts
+++ b/src/app/core/layout/header/header.spec.ts
@@ -14,6 +14,7 @@ describe('HeaderComponent', () => {
   let fixture: ComponentFixture<HeaderComponent>;
 
   const getHeader = (): HTMLElement => fixture.nativeElement.querySelector('header');
+  const getNavigation = (): HTMLElement => fixture.nativeElement.querySelector('app-navigation')!;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/src/app/core/layout/header/header.spec.ts
+++ b/src/app/core/layout/header/header.spec.ts
@@ -15,6 +15,7 @@ describe('HeaderComponent', () => {
 
   const getHeader = (): HTMLElement => fixture.nativeElement.querySelector('header');
   const getNavigation = (): HTMLElement => fixture.nativeElement.querySelector('app-navigation')!;
+  const getAuthActions = (): HTMLElement => fixture.nativeElement.querySelector('app-auth-actions')!;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -57,7 +58,7 @@ describe('HeaderComponent', () => {
     });
 
     it('should render AuthActionsComponent', () => {
-      const authActions = fixture.nativeElement.querySelector('app-auth-actions');
+      const authActions = getAuthActions();
       expect(authActions).toBeTruthy();
     });
 
@@ -67,8 +68,8 @@ describe('HeaderComponent', () => {
 
     it('should contain app-navigation before app-auth-actions', () => {
       const header = getHeader();
-      const navigation = getNavigation()!;
-      const authActions = header.querySelector('app-auth-actions')!;
+      const navigation = getNavigation();
+      const authActions = getAuthActions();
 
       expect(navigation).toBeTruthy();
       expect(authActions).toBeTruthy();

--- a/src/app/core/layout/navigation/navigation.spec.ts
+++ b/src/app/core/layout/navigation/navigation.spec.ts
@@ -121,12 +121,12 @@ describe('NavigationComponent', () => {
     it('should react to isLogged changes', () => {
       setLoggedIn(true);
 
-      let linksList = fixture.nativeElement.querySelector('.navbar__links');
+      let linksList = getLinksList();
       expect(linksList).toBeTruthy();
 
       setLoggedIn(false);
 
-      linksList = fixture.nativeElement.querySelector('.navbar__links');
+      linksList = getLinksList();
       expect(linksList).toBeFalsy();
     });
 

--- a/src/app/core/layout/navigation/navigation.spec.ts
+++ b/src/app/core/layout/navigation/navigation.spec.ts
@@ -69,14 +69,14 @@ describe('NavigationComponent', () => {
     it('should render all navigation links when user is logged', () => {
       setLoggedIn(true);
 
-      const links = fixture.nativeElement.querySelectorAll('.navbar__links li a');
+      const links = getLinks();
       expect(links).toHaveSize(4);
     });
 
     it('should have correct routerLink for each navigation link', () => {
       setLoggedIn(true);
 
-      const links = fixture.nativeElement.querySelectorAll('.navbar__links li a');
+      const links = getLinks();
       const expectedLinks = ['/', '/map', '/calendar', '/graphics'];
 
       links.forEach((link: HTMLElement, index: number) => {
@@ -89,7 +89,7 @@ describe('NavigationComponent', () => {
     it('should render correct icons and labels for each link', () => {
       setLoggedIn(true);
 
-      const links = fixture.nativeElement.querySelectorAll('.navbar__links li a');
+      const links = getLinks();
       const expectedIcons = ['pi-home', 'pi-map', 'pi-calendar', 'pi-chart-bar'];
       const expectedLabels = [
         component.navigationMsg.links.home,
@@ -137,7 +137,7 @@ describe('NavigationComponent', () => {
     it('should set aria-current to null on inactive links', () => {
       setLoggedIn(true);
 
-      const links = fixture.nativeElement.querySelectorAll('.navbar__links li a');
+      const links = getLinks();
 
       links.forEach((link: HTMLElement) => {
         const ariaCurrent = link.getAttribute('aria-current');

--- a/src/app/core/layout/navigation/navigation.spec.ts
+++ b/src/app/core/layout/navigation/navigation.spec.ts
@@ -148,7 +148,7 @@ describe('NavigationComponent', () => {
     it('should have aria-hidden on all nav icons', () => {
       setLoggedIn(true);
 
-      const icons = fixture.nativeElement.querySelectorAll('.navbar__links li a i');
+      const icons = getIcons();
 
       icons.forEach((icon: HTMLElement) => {
         expect(icon.getAttribute('aria-hidden')).toBe('true');

--- a/src/app/core/layout/navigation/navigation.spec.ts
+++ b/src/app/core/layout/navigation/navigation.spec.ts
@@ -119,15 +119,11 @@ describe('NavigationComponent', () => {
     });
 
     it('should react to isLogged changes', () => {
-      setLoggedIn(true);
-
-      let linksList = getLinksList();
-      expect(linksList).toBeTruthy();
-
       setLoggedIn(false);
+      expect(getLinksList()).toBeFalsy();
 
-      linksList = getLinksList();
-      expect(linksList).toBeFalsy();
+      setLoggedIn(true);
+      expect(getLinksList()).toBeTruthy();
     });
 
   });

--- a/src/app/core/layout/navigation/navigation.spec.ts
+++ b/src/app/core/layout/navigation/navigation.spec.ts
@@ -55,14 +55,14 @@ describe('NavigationComponent', () => {
     it('should render the links list when user is logged', () => {
       setLoggedIn(true);
 
-      const unorderListElement = fixture.nativeElement.querySelector('.navbar__links');
+      const unorderListElement = getLinksList();
       expect(unorderListElement).toBeTruthy();
     });
 
     it('should NOT render links list when user is not logged', () => {
       setLoggedIn(false);
 
-      const unorderListElement = fixture.nativeElement.querySelector('.navbar__links');
+      const unorderListElement = getLinksList();
       expect(unorderListElement).toBeFalsy();
     });
 

--- a/src/app/core/layout/navigation/navigation.spec.ts
+++ b/src/app/core/layout/navigation/navigation.spec.ts
@@ -18,7 +18,7 @@ describe('NavigationComponent', () => {
   const getLinksList = (): HTMLElement | null => fixture.nativeElement.querySelector('.navbar__links');
   const getLinks = (): NodeListOf<HTMLAnchorElement> => fixture.nativeElement.querySelectorAll('.navbar__links li a');
   const getIcons = (): NodeListOf<HTMLElement> => fixture.nativeElement.querySelectorAll('.navbar__links li a i');
-  
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [NavigationComponent],
@@ -46,10 +46,10 @@ describe('NavigationComponent', () => {
   describe('Template rendering', () => {
 
     it('should render the nav element with correct role and aria-label', () => {
-      const navElement = fixture.nativeElement.querySelector('nav');
+      const navElement = getNav();
 
-      expect(navElement.getAttribute('role')).toBe('navigation');
-      expect(navElement.getAttribute('aria-label')).toBe(component.navigationMsg.aria.nav);
+      expect(navElement?.getAttribute('role')).toBe('navigation');
+      expect(navElement?.getAttribute('aria-label')).toBe(component.navigationMsg.aria.nav);
     });
 
     it('should render the links list when user is logged', () => {

--- a/src/app/core/layout/navigation/navigation.spec.ts
+++ b/src/app/core/layout/navigation/navigation.spec.ts
@@ -65,7 +65,7 @@ describe('NavigationComponent', () => {
       setLoggedIn(true);
 
       const links = fixture.nativeElement.querySelectorAll('.navbar__links li a');
-      expect(links.length).toBe(4);
+      expect(links).toHaveSize(4);
     });
 
     it('should have correct routerLink for each navigation link', () => {

--- a/src/app/core/layout/navigation/navigation.spec.ts
+++ b/src/app/core/layout/navigation/navigation.spec.ts
@@ -14,6 +14,11 @@ describe('NavigationComponent', () => {
   let fixture: ComponentFixture<NavigationComponent>;
   let authService: MockAuthService;
 
+  const getNav = (): HTMLElement | null => fixture.nativeElement.querySelector('nav');
+  const getLinksList = (): HTMLElement | null => fixture.nativeElement.querySelector('.navbar__links');
+  const getLinks = (): NodeListOf<HTMLAnchorElement> => fixture.nativeElement.querySelectorAll('.navbar__links li a');
+  const getIcons = (): NodeListOf<HTMLElement> => fixture.nativeElement.querySelectorAll('.navbar__links li a i');
+  
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [NavigationComponent],


### PR DESCRIPTION
### [Task Here](https://github.com/JordiMiravet/FleetManager-Frontend/issues/295)

## Summary

Improve the readability, maintainability and consistency of the core layout component test suites by refining existing assertions, extracting reusable query helpers and improving test organization.

The changes keep the current behavior unchanged while making the tests easier to understand, maintain and extend across layout components.

## What's included

- Improved `AccountDrawerComponent` tests by refining assertions, improving query reuse and increasing test readability.
- Enhanced `AuthActionsComponent` tests by extracting reusable DOM query helpers and replacing duplicated template queries.
- Improved `HeaderComponent` tests by introducing reusable element selectors and cleaning up repeated DOM access patterns.
- Updated `NavigationComponent` tests by extracting query helpers for navigation elements, links and icons, and improving assertion consistency.
- Improved test maintainability by reducing duplicated `querySelector` calls and centralizing template element access.
- Refined test assertions to use clearer and more reliable matchers where applicable.

## Notes

- No backend changes were required.
- No authentication logic changes were included.
- No user-facing behavior changes were introduced.
- Changes are limited to frontend test improvements, readability improvements and test maintainability.